### PR TITLE
Add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,10 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+addons:
+  apt:
+    sources:
+      - george-edison55-precise-backports
+    packages:
+      - cmake
+      - cmake-data


### PR DESCRIPTION
Hopefully, we can throw this file away at some point. CI configuration
does not belong in the repo, but most current services require you to
perform this pollution.

Resolves #21.