### PR TITLE
Make Lines and Trailers accessible via the LineIteratorExt

### DIFF
--- a/lib/src/message/line.rs
+++ b/lib/src/message/line.rs
@@ -48,15 +48,20 @@ impl<'a> From<&'a str> for Line {
 
 
 #[derive(Debug)]
-pub struct Lines<'a>(Peekable<str::Lines<'a>>);
+pub struct Lines<'a, I>(Peekable<I>)
+    where I: Iterator<Item = &'a str>;
 
-impl<'a> From<str::Lines<'a>> for Lines<'a> {
-    fn from(lines: str::Lines<'a>) -> Self {
+impl<'a, I> From<I> for Lines<'a, I>
+    where I: Iterator<Item = &'a str>
+{
+    fn from(lines: I) -> Self {
         Lines(lines.peekable())
     }
 }
 
-impl<'a> Iterator for Lines<'a> {
+impl<'a, I> Iterator for Lines<'a, I>
+    where I: Iterator<Item = &'a str>
+{
     type Item = Line;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/lib/src/message/line.rs
+++ b/lib/src/message/line.rs
@@ -10,7 +10,6 @@
 use message::trailer::{Trailer, TrailerKey, TrailerValue};
 use regex::Regex;
 use std::iter::Peekable;
-use std::str;
 
 
 /// A line of an issue message
@@ -50,12 +49,6 @@ impl<'a> From<&'a str> for Line {
 
 #[derive(Debug)]
 pub struct Lines<'a>(Peekable<str::Lines<'a>>);
-
-impl<'a> Lines<'a> {
-    pub fn new(text: &'a str) -> Lines<'a> {
-        Lines::from(text.lines())
-    }
-}
 
 impl<'a> From<str::Lines<'a>> for Lines<'a> {
     fn from(lines: str::Lines<'a>) -> Self {

--- a/lib/src/message/line.rs
+++ b/lib/src/message/line.rs
@@ -48,30 +48,33 @@ impl<'a> From<&'a str> for Line {
 
 
 #[derive(Debug)]
-pub struct Lines<'a, I>(Peekable<I>)
-    where I: Iterator<Item = &'a str>;
+pub struct Lines<I, S>(Peekable<I>)
+    where I: Iterator<Item = S>,
+          S: AsRef<str>;
 
-impl<'a, I> From<I> for Lines<'a, I>
-    where I: Iterator<Item = &'a str>
+impl<I, S> From<I> for Lines<I, S>
+    where I: Iterator<Item = S>,
+          S: AsRef<str>
 {
     fn from(lines: I) -> Self {
         Lines(lines.peekable())
     }
 }
 
-impl<'a, I> Iterator for Lines<'a, I>
-    where I: Iterator<Item = &'a str>
+impl<I, S> Iterator for Lines<I, S>
+    where I: Iterator<Item = S>,
+          S: AsRef<str>
 {
     type Item = Line;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.0.next().map(|line| Line::from(line)) {
+        match self.0.next().map(|line| Line::from(line.as_ref())) {
             Some(Line::Trailer(mut trailer)) => {
                 // accumulate potential multiline trailer
                 // TODO: also respect other whitespace
-                while self.0.peek().map_or(false, |l| l.starts_with(" ")) {
+                while self.0.peek().map_or(false, |l| l.as_ref().starts_with(" ")) {
                     // we have to consume the line we peeked at
-                    trailer.value = trailer.value.append(self.0.next().unwrap());
+                    trailer.value = trailer.value.append(self.0.next().unwrap().as_ref());
                 }
 
                 Some(Line::Trailer(trailer))

--- a/lib/src/message/line.rs
+++ b/lib/src/message/line.rs
@@ -24,14 +24,14 @@ pub enum Line {
     Blank
 }
 
-impl<'a> From<&'a str> for Line {
-    fn from(line :&'a str) -> Self {
+impl<S: AsRef<str>> From<S> for Line {
+    fn from(line: S) -> Self {
         lazy_static! {
             // regex to match the beginning of a trailer
             static ref RE: Regex = Regex::new(r"^(?P<key>([^[:space:]]+)):\ (?P<value>(.*))$").unwrap();
         }
 
-        let trimmed = line.trim_right();
+        let trimmed = line.as_ref().trim_right();
         if trimmed.is_empty() {
             return Line::Blank;
         }
@@ -68,7 +68,7 @@ impl<I, S> Iterator for Lines<I, S>
     type Item = Line;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.0.next().map(|line| Line::from(line.as_ref())) {
+        match self.0.next().as_ref().map(Line::from) {
             Some(Line::Trailer(mut trailer)) => {
                 // accumulate potential multiline trailer
                 // TODO: also respect other whitespace

--- a/lib/src/message/mod.rs
+++ b/lib/src/message/mod.rs
@@ -49,6 +49,14 @@ pub trait LineIteratorExt {
     /// The iterator returned by this function will return categorized lines.
     ///
     fn categorized_lines(self) -> line::Lines<Self::Iter, String>;
+
+    /// Create an iterator for extracting trailers
+    ///
+    /// Ths iterator returned will only yield trailers in the message. Strings
+    /// resembling trailers which co-exist with regular text-lines in a block of
+    /// non-blank lines will be ignored (e.g. not returned).
+    ///
+    fn trailers(self) -> trailer::Trailers<Self::Iter, String>;
 }
 
 impl<L> LineIteratorExt for L
@@ -74,6 +82,10 @@ impl<L> LineIteratorExt for L
 
     fn categorized_lines(self) -> line::Lines<Self::Iter, String> {
         line::Lines::from(self)
+    }
+
+    fn trailers(self) -> trailer::Trailers<Self::Iter, String> {
+        trailer::Trailers::from(self)
     }
 }
 

--- a/lib/src/message/mod.rs
+++ b/lib/src/message/mod.rs
@@ -43,6 +43,12 @@ pub trait LineIteratorExt {
     /// or end of a message.
     ///
     fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter>>;
+
+    /// Create an iterator for categorizing lines
+    ///
+    /// The iterator returned by this function will return categorized lines.
+    ///
+    fn categorized_lines(self) -> line::Lines<Self::Iter, String>;
 }
 
 impl<L> LineIteratorExt for L
@@ -64,6 +70,10 @@ impl<L> LineIteratorExt for L
 
     fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter>> {
         self.without_comments().strip_whitespace_right()
+    }
+
+    fn categorized_lines(self) -> line::Lines<Self::Iter, String> {
+        line::Lines::from(self)
     }
 }
 

--- a/lib/src/message/trailer.rs
+++ b/lib/src/message/trailer.rs
@@ -9,7 +9,6 @@
 
 use message::line::{Line, Lines};
 use std::collections::VecDeque;
-use std::str;
 
 /// The Key of a Trailer:
 ///
@@ -121,28 +120,39 @@ impl<'l> TrailerCollector<'l> {
 }
 
 
-pub struct Trailers<'a> {
-    lines: Lines<str::Lines<'a>, &'a str>,
+pub struct Trailers<I, S>
+    where I: Iterator<Item = S>,
+          S: AsRef<str>
+{
+    lines: Lines<I, S>,
     buf: VecDeque<Trailer>,
 }
 
-impl<'a> Trailers<'a> {
+impl<I, S> Trailers<I, S>
+    where I: Iterator<Item = S>,
+          S: AsRef<str>
+{
+    pub fn only_dit(self) -> DitTrailers<I, S> {
+        DitTrailers(self)
+    }
+}
 
-    /// Create a new Trailers iterator from a commit message
-    pub fn new(text: &'a str) -> Trailers<'a> {
+impl<I, S> From<I> for Trailers<I, S>
+    where I: Iterator<Item = S>,
+          S: AsRef<str>
+{
+    fn from(lines: I) -> Self {
         Trailers {
-            lines: Lines::from(text.lines()),
+            lines: Lines::from(lines),
             buf: VecDeque::new(),
         }
     }
-
-    pub fn only_dit(self) -> DitTrailers<'a> {
-        DitTrailers(self)
-    }
-
 }
 
-impl<'a> Iterator for Trailers<'a> {
+impl<I, S> Iterator for Trailers<I, S>
+    where I: Iterator<Item = S>,
+          S: AsRef<str>
+{
     type Item = Trailer;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -172,9 +182,14 @@ impl<'a> Iterator for Trailers<'a> {
 
 }
 
-pub struct DitTrailers<'a>(Trailers<'a>);
+pub struct DitTrailers<I, S>(Trailers<I, S>)
+    where I: Iterator<Item = S>,
+          S: AsRef<str>;
 
-impl<'a> Iterator for DitTrailers<'a> {
+impl<I, S> Iterator for DitTrailers<I, S>
+    where I: Iterator<Item = S>,
+          S: AsRef<str>
+{
     type Item = Trailer;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/lib/src/message/trailer.rs
+++ b/lib/src/message/trailer.rs
@@ -9,6 +9,7 @@
 
 use message::line::{Line, Lines};
 use std::collections::VecDeque;
+use std::str;
 
 /// The Key of a Trailer:
 ///
@@ -130,7 +131,7 @@ impl<'a> Trailers<'a> {
     /// Create a new Trailers iterator from a commit message
     pub fn new(text: &'a str) -> Trailers<'a> {
         Trailers {
-            lines: Lines::new(text),
+            lines: Lines::from(text.lines()),
             buf: VecDeque::new(),
         }
     }

--- a/lib/src/message/trailer.rs
+++ b/lib/src/message/trailer.rs
@@ -122,7 +122,7 @@ impl<'l> TrailerCollector<'l> {
 
 
 pub struct Trailers<'a> {
-    lines: Lines<'a>,
+    lines: Lines<'a, str::Lines<'a>>,
     buf: VecDeque<Trailer>,
 }
 

--- a/lib/src/message/trailer.rs
+++ b/lib/src/message/trailer.rs
@@ -122,7 +122,7 @@ impl<'l> TrailerCollector<'l> {
 
 
 pub struct Trailers<'a> {
-    lines: Lines<'a, str::Lines<'a>>,
+    lines: Lines<str::Lines<'a>, &'a str>,
     buf: VecDeque<Trailer>,
 }
 


### PR DESCRIPTION
This PR generalizes `Lines` and `Trailers` and makes them accessible via `LineIteratorExt`, rounding up the interface.