### PR TITLE
Add an extension trait for commits

### DIFF
--- a/lib/src/iter.rs
+++ b/lib/src/iter.rs
@@ -54,52 +54,60 @@ impl<'r> From<ReferenceNames<'r>> for HeadRefsToIssuesIter<'r> {
 
 /// A trait to strip whitespace from a thing that consists of several strings, for example the
 /// `std::str::Lines` iterator.
-pub trait StripWhiteSpace<I: Iterator<Item = String> + Sized> {
-    fn strip_whitespace_left(self)  -> StripWhiteSpaceLeftIter<I>;
-    fn strip_whitespace_right(self) -> StripWhiteSpaceRightIter<I>;
+pub trait StripWhiteSpace<I, S>
+    where I: Iterator<Item = S> + Sized,
+          S: AsRef<str>
+{
+    fn strip_whitespace_left(self)  -> StripWhiteSpaceLeftIter<I, S>;
+    fn strip_whitespace_right(self) -> StripWhiteSpaceRightIter<I, S>;
 }
 
 /// Implement the StripWhiteSpace extension trait for all things where we can iterate over String
 /// objects.
 /// This implements StripWhiteSpace<String> for type String automatically, apparently.
-impl<I> StripWhiteSpace<I> for I
-    where I: Iterator<Item = String> + Sized
+impl<I, S> StripWhiteSpace<I, S> for I
+    where I: Iterator<Item = S> + Sized,
+          S: AsRef<str>
 {
-    fn strip_whitespace_left(self) -> StripWhiteSpaceLeftIter<I> {
+    fn strip_whitespace_left(self) -> StripWhiteSpaceLeftIter<I, S> {
         StripWhiteSpaceLeftIter(self)
     }
-    fn strip_whitespace_right(self) -> StripWhiteSpaceRightIter<I> {
+    fn strip_whitespace_right(self) -> StripWhiteSpaceRightIter<I, S> {
         StripWhiteSpaceRightIter(self)
     }
 }
 
 /// A Iterator type which iterates over String objects, used to strip whitespace from an iterator
 /// over String.
-pub struct StripWhiteSpaceLeftIter<I>(I)
-    where I: Iterator<Item = String> + Sized;
+pub struct StripWhiteSpaceLeftIter<I, S>(I)
+    where I: Iterator<Item = S> + Sized,
+          S: AsRef<str>;
 
-impl<I> Iterator for StripWhiteSpaceLeftIter<I>
-    where I: Iterator<Item = String> + Sized
+impl<'a, I, S> Iterator for StripWhiteSpaceLeftIter<I, S>
+    where I: Iterator<Item = S> + Sized,
+          S: AsRef<str>
 {
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|s| String::from(s.trim_left()))
+        self.0.next().map(|s| String::from(s.as_ref().trim_left()))
     }
 }
 
 /// A Iterator type which iterates over String objects, used to strip whitespace from an iterator
 /// over String.
-pub struct StripWhiteSpaceRightIter<I>(I)
-    where I: Iterator<Item = String> + Sized;
+pub struct StripWhiteSpaceRightIter<I, S>(I)
+    where I: Iterator<Item = S> + Sized,
+          S: AsRef<str>;
 
-impl<I> Iterator for StripWhiteSpaceRightIter<I>
-    where I: Iterator<Item = String> + Sized
+impl<'a, I, S> Iterator for StripWhiteSpaceRightIter<I, S>
+    where I: Iterator<Item = S> + Sized,
+          S: AsRef<str>
 {
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|s| String::from(s.trim_right()))
+        self.0.next().map(|s| String::from(s.as_ref().trim_right()))
     }
 }
 

--- a/lib/src/iter.rs
+++ b/lib/src/iter.rs
@@ -113,34 +113,38 @@ impl<'a, I, S> Iterator for StripWhiteSpaceRightIter<I, S>
 
 /// Extension trait for everything that iterates over Strings, to remove comment lines
 /// (Lines starting with "#")
-pub trait WithoutComments<I>
-    where I: Iterator<Item = String> + Sized
+pub trait WithoutComments<I, S>
+    where I: Iterator<Item = S> + Sized,
+          S: AsRef<str>
 {
-    fn without_comments(self) -> WithoutCommentsIter<I>;
+    fn without_comments(self) -> WithoutCommentsIter<I, S>;
 }
 
 /// Iterator type to be returned from WithoutComments::without_comments.
-pub struct WithoutCommentsIter<I>(I)
-    where I: Iterator<Item = String> + Sized;
+pub struct WithoutCommentsIter<I, S>(I)
+    where I: Iterator<Item = S> + Sized,
+          S: AsRef<str>;
 
-impl<I> WithoutComments<I> for I
-    where I: Iterator<Item = String> + Sized
+impl<I, S> WithoutComments<I, S> for I
+    where I: Iterator<Item = S> + Sized,
+          S: AsRef<str>
 {
-    fn without_comments(self) -> WithoutCommentsIter<I> {
+    fn without_comments(self) -> WithoutCommentsIter<I, S> {
         WithoutCommentsIter(self)
     }
 }
 
-impl<I> Iterator for WithoutCommentsIter<I>
-    where I: Iterator<Item = String> + Sized
+impl<I, S> Iterator for WithoutCommentsIter<I, S>
+    where I: Iterator<Item = S> + Sized,
+          S: AsRef<str>
 {
-    type Item = String;
+    type Item = S;
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(next) = self.0.next() {
             // we do not trim whitespace here, because of code blocks in the message which might
             // have a "#" at the beginning
-            if !next.starts_with("#") {
+            if !next.as_ref().starts_with("#") {
                 return Some(next)
             }
         }

--- a/lib/src/message/mod.rs
+++ b/lib/src/message/mod.rs
@@ -42,7 +42,7 @@ pub trait LineIteratorExt {
     /// Note that the iterator does not (yet) strip blank lines at the beginning
     /// or end of a message.
     ///
-    fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter>, String>;
+    fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter, String>, String>;
 
     /// Create an iterator for categorizing lines
     ///
@@ -76,7 +76,7 @@ impl<L> LineIteratorExt for L
         Ok(())
     }
 
-    fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter>, String> {
+    fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter, String>, String> {
         self.without_comments().strip_whitespace_right()
     }
 

--- a/lib/src/message/mod.rs
+++ b/lib/src/message/mod.rs
@@ -116,6 +116,14 @@ pub trait CommitExt {
     /// Get the commit message's body as a sequence of lines
     ///
     fn body_lines<'a>(&'a self) -> BodyLines<'a>;
+
+    /// Get the commit message's body as a sequence of categorized lines
+    ///
+    fn categorized_body<'a>(&'a self) -> line::Lines<BodyLines<'a>, &'a str>;
+
+    /// Get an iterator over all the trailers in the commit message's body
+    ///
+    fn trailers<'a>(&'a self) -> trailer::Trailers<BodyLines<'a>, &'a str>;
 }
 
 impl<'c> CommitExt for Commit<'c> {
@@ -125,6 +133,14 @@ impl<'c> CommitExt for Commit<'c> {
 
     fn body_lines<'a>(&'a self) -> BodyLines<'a> {
         self.message_lines().skip(2)
+    }
+
+    fn categorized_body<'a>(&'a self) -> line::Lines<BodyLines<'a>, &'a str> {
+        self.body_lines().categorized_lines()
+    }
+
+    fn trailers<'a>(&'a self) -> trailer::Trailers<BodyLines<'a>, &'a str> {
+        self.body_lines().trailers()
     }
 }
 

--- a/lib/src/message/mod.rs
+++ b/lib/src/message/mod.rs
@@ -22,8 +22,10 @@ pub mod trailer;
 /// commit messages. It is intended for use on iterators over the lines of a
 /// message.
 ///
-pub trait LineIteratorExt {
-    type Iter : Iterator<Item = String>;
+pub trait LineIteratorExt<S>
+    where S: AsRef<str>
+{
+    type Iter : Iterator<Item = S>;
 
     /// Check whether the formatting of a message is valid
     ///
@@ -42,13 +44,13 @@ pub trait LineIteratorExt {
     /// Note that the iterator does not (yet) strip blank lines at the beginning
     /// or end of a message.
     ///
-    fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter, String>, String>;
+    fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter, S>, S>;
 
     /// Create an iterator for categorizing lines
     ///
     /// The iterator returned by this function will return categorized lines.
     ///
-    fn categorized_lines(self) -> line::Lines<Self::Iter, String>;
+    fn categorized_lines(self) -> line::Lines<Self::Iter, S>;
 
     /// Create an iterator for extracting trailers
     ///
@@ -56,35 +58,36 @@ pub trait LineIteratorExt {
     /// resembling trailers which co-exist with regular text-lines in a block of
     /// non-blank lines will be ignored (e.g. not returned).
     ///
-    fn trailers(self) -> trailer::Trailers<Self::Iter, String>;
+    fn trailers(self) -> trailer::Trailers<Self::Iter, S>;
 }
 
-impl<L> LineIteratorExt for L
-    where L: Iterator<Item = String>
+impl<L, S> LineIteratorExt<S> for L
+    where L: Iterator<Item = S>,
+          S: AsRef<str>
 {
     type Iter = L;
 
     fn check_message_format(mut self) -> Result<()> {
-        if try!(self.next().ok_or(Error::from_kind(EK::EmptyMessage))).is_empty() {
+        if try!(self.next().ok_or(Error::from_kind(EK::EmptyMessage))).as_ref().is_empty() {
             return Err(Error::from_kind(EK::EmptySubject))
         }
 
-        if !self.next().map(|line| line.is_empty()).unwrap_or(true) {
+        if !self.next().map(|line| line.as_ref().is_empty()).unwrap_or(true) {
             return Err(Error::from_kind(EK::MalformedMessage));
         }
 
         Ok(())
     }
 
-    fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter, String>, String> {
+    fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter, S>, S> {
         self.without_comments().strip_whitespace_right()
     }
 
-    fn categorized_lines(self) -> line::Lines<Self::Iter, String> {
+    fn categorized_lines(self) -> line::Lines<Self::Iter, S> {
         line::Lines::from(self)
     }
 
-    fn trailers(self) -> trailer::Trailers<Self::Iter, String> {
+    fn trailers(self) -> trailer::Trailers<Self::Iter, S> {
         trailer::Trailers::from(self)
     }
 }

--- a/lib/src/message/mod.rs
+++ b/lib/src/message/mod.rs
@@ -42,7 +42,7 @@ pub trait LineIteratorExt {
     /// Note that the iterator does not (yet) strip blank lines at the beginning
     /// or end of a message.
     ///
-    fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter>>;
+    fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter>, String>;
 
     /// Create an iterator for categorizing lines
     ///
@@ -76,7 +76,7 @@ impl<L> LineIteratorExt for L
         Ok(())
     }
 
-    fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter>> {
+    fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter>, String> {
         self.without_comments().strip_whitespace_right()
     }
 

--- a/lib/src/message/mod.rs
+++ b/lib/src/message/mod.rs
@@ -96,6 +96,11 @@ impl<L, S> LineIteratorExt<S> for L
 }
 
 
+/// Type representing the lines composing the body part of a commit message
+///
+pub type BodyLines<'a> = Skip<str::Lines<'a>>;
+
+
 /// Extension for commit
 ///
 /// This extension gives a more convenient access to message functionality via
@@ -110,7 +115,7 @@ pub trait CommitExt {
 
     /// Get the commit message's body as a sequence of lines
     ///
-    fn body_lines<'a>(&'a self) -> Skip<str::Lines<'a>>;
+    fn body_lines<'a>(&'a self) -> BodyLines<'a>;
 }
 
 impl<'c> CommitExt for Commit<'c> {
@@ -118,7 +123,7 @@ impl<'c> CommitExt for Commit<'c> {
         self.message().unwrap_or("").lines()
     }
 
-    fn body_lines<'a>(&'a self) -> Skip<str::Lines<'a>> {
+    fn body_lines<'a>(&'a self) -> BodyLines<'a> {
         self.message_lines().skip(2)
     }
 }

--- a/lib/src/message/mod.rs
+++ b/lib/src/message/mod.rs
@@ -9,8 +9,11 @@
 
 use error::*;
 use error::ErrorKind as EK;
+use git2::Commit;
 use iter::{StripWhiteSpace, StripWhiteSpaceRightIter};
 use iter::{WithoutComments, WithoutCommentsIter};
+use std::iter::Skip;
+use std::str;
 
 pub mod line;
 pub mod trailer;
@@ -89,6 +92,34 @@ impl<L, S> LineIteratorExt<S> for L
 
     fn trailers(self) -> trailer::Trailers<Self::Iter, S> {
         trailer::Trailers::from(self)
+    }
+}
+
+
+/// Extension for commit
+///
+/// This extension gives a more convenient access to message functionality via
+/// `git2::Commit`.
+///
+pub trait CommitExt {
+    /// Get the commit message as a sequence of lines
+    ///
+    /// If the commit has no message, an empty message will be simulated.
+    ///
+    fn message_lines<'a>(&'a self) -> str::Lines<'a>;
+
+    /// Get the commit message's body as a sequence of lines
+    ///
+    fn body_lines<'a>(&'a self) -> Skip<str::Lines<'a>>;
+}
+
+impl<'c> CommitExt for Commit<'c> {
+    fn message_lines<'a>(&'a self) -> str::Lines<'a> {
+        self.message().unwrap_or("").lines()
+    }
+
+    fn body_lines<'a>(&'a self) -> Skip<str::Lines<'a>> {
+        self.message_lines().skip(2)
     }
 }
 


### PR DESCRIPTION
This PR adds an extension trait for `git2::Commit`s, providing convenient access to some functionality. For this purpose, the `LineIteratorExt` is generalized, continuing the efforts of #57.