### PR TITLE
Additions to the message module

### DIFF
--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -40,6 +40,11 @@ error_chain! {
             display("Malformed head refernece: {}", name)
         }
 
+        TrailerFormatError(trailer: String) {
+            description("Found malformed trailer")
+            display("Malformed trailer: {}", trailer)
+        }
+
         EmptyMessage {
             description("An empty message was supplied")
             display("The message is empty")

--- a/lib/src/message/line.rs
+++ b/lib/src/message/line.rs
@@ -7,9 +7,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use message::trailer::{Trailer, TrailerKey, TrailerValue};
-use regex::Regex;
+use message::trailer::Trailer;
 use std::iter::Peekable;
+use std::str::FromStr;
 
 
 /// A line of an issue message
@@ -26,21 +26,13 @@ pub enum Line {
 
 impl<S: AsRef<str>> From<S> for Line {
     fn from(line: S) -> Self {
-        lazy_static! {
-            // regex to match the beginning of a trailer
-            static ref RE: Regex = Regex::new(r"^([[:alnum:]-]+):(.*)$").unwrap();
-        }
-
         let trimmed = line.as_ref().trim_right();
         if trimmed.is_empty() {
             return Line::Blank;
         }
 
-        match RE.captures(trimmed).map(|c| (c.get(1), c.get(2))) {
-            Some((Some(key), Some(value))) => Line::Trailer(Trailer {
-                key  : TrailerKey::from(String::from(key.as_str())),
-                value: TrailerValue::from_slice(value.as_str().trim()),
-            }),
+        match Trailer::from_str(trimmed) {
+            Ok(trailer) => Line::Trailer(trailer),
             _ => Line::Text(String::from(trimmed)),
         }
     }

--- a/lib/src/message/mod.rs
+++ b/lib/src/message/mod.rs
@@ -63,6 +63,10 @@ pub trait LineIteratorExt<S>
     /// non-blank lines will be ignored (e.g. not returned).
     ///
     fn trailers(self) -> trailer::Trailers<Self::Iter, S>;
+
+    /// Accumulate the lines into a single string
+    ///
+    fn collect_string(self) -> String;
 }
 
 impl<L, S> LineIteratorExt<S> for L
@@ -93,6 +97,14 @@ impl<L, S> LineIteratorExt<S> for L
 
     fn trailers(self) -> trailer::Trailers<Self::Iter, S> {
         trailer::Trailers::from(self)
+    }
+
+    fn collect_string(self) -> String {
+        self.fold(String::new(), |mut res, line| {
+            res.push_str(line.as_ref());
+            res.push('\n');
+            res
+        })
     }
 }
 

--- a/lib/src/message/trailer.rs
+++ b/lib/src/message/trailer.rs
@@ -10,6 +10,7 @@
 use message::line::{Line, Lines};
 use std::collections::VecDeque;
 use std::fmt::{self, Display, Formatter};
+use std::result::Result as RResult;
 
 /// The Key of a Trailer:
 ///
@@ -29,7 +30,7 @@ impl From<String> for TrailerKey {
 }
 
 impl Display for TrailerKey {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut Formatter) -> RResult<(), fmt::Error> {
         write!(f, "{}", self.0)
     }
 }
@@ -76,7 +77,7 @@ impl TrailerValue {
 }
 
 impl Display for TrailerValue {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut Formatter) -> RResult<(), fmt::Error> {
         match *self {
             TrailerValue::Int(i)        => write!(f, "{}", i),
             TrailerValue::String(ref s) => write!(f, "{}", s),
@@ -98,7 +99,7 @@ impl Into<(TrailerKey, TrailerValue)> for Trailer {
 }
 
 impl Display for Trailer {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut Formatter) -> RResult<(), fmt::Error> {
         write!(f, "{}: {}", self.key, self.value)
     }
 }

--- a/lib/src/message/trailer.rs
+++ b/lib/src/message/trailer.rs
@@ -92,6 +92,15 @@ pub struct Trailer {
     pub value: TrailerValue,
 }
 
+impl Trailer {
+    pub fn new(key: &str, value: &str) -> Trailer {
+        Trailer {
+            key  : TrailerKey::from(String::from(key)),
+            value: TrailerValue::from_slice(value),
+        }
+    }
+}
+
 impl Into<(TrailerKey, TrailerValue)> for Trailer {
     fn into(self) -> (TrailerKey, TrailerValue) {
         (self.key, self.value)


### PR DESCRIPTION
This PR introduces some new interfaces to the `message` module of the library and refactors a few things on the way. In preparation for #67.