### PR TITLE
Fix commitmsg_edit_path()

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -84,7 +84,7 @@ impl<'r> RepositoryUtil<'r> for Repository {
     }
 
     fn commitmsg_edit_path(&self) -> PathBuf {
-        self.path().with_file_name("COMMIT_EDITMSG")
+        self.path().join("COMMIT_EDITMSG")
     }
 
     fn get_commit_msg(&self, path: PathBuf) -> Result<Vec<String>> {


### PR DESCRIPTION
`with_file_name()` didn't work as expected, resulting in an
`COMMIT_EDITMSG` file in the wrong directory. This commit replaces this
function with a `join()`, which always appends the file name to the
path.