### PR TITLE
Aborting iterator

### DIFF
--- a/src/abort.rs
+++ b/src/abort.rs
@@ -45,3 +45,22 @@ impl<I, V, E> Iterator for AbortingIter<I, V, E>
     }
 }
 
+
+/// Extension trait for convenient creation of `AbortingIter`s
+///
+pub trait IteratorExt<I, V, E>
+    where I: Iterator<Item = Result<V, E>> + Sized
+{
+    /// Wrap this instance in an aborting iterator
+    ///
+    fn abort_on_err(self) -> AbortingIter<I, V, E>;
+}
+
+impl<I, V, E> IteratorExt<I, V, E> for I
+    where I: Iterator<Item = Result<V, E>> + Sized
+{
+    fn abort_on_err(self) -> AbortingIter<I, V, E> {
+        AbortingIter::from(self)
+    }
+}
+

--- a/src/abort.rs
+++ b/src/abort.rs
@@ -1,0 +1,47 @@
+//   git-dit - the distributed issue tracker for git
+//   Copyright (C) 2017 Matthias Beyer <mail@beyermatthias.de>
+//   Copyright (C) 2017 Julian Ganz <neither@nut.email>
+//
+//   This program is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License version 2 as
+//   published by the Free Software Foundation.
+//
+
+use std::fmt::Debug;
+use std::process::exit;
+
+/// Aborting iterator
+///
+/// Unwraps items and aborts (calls `exit(1)) if an error value was encountered.
+/// It yields the unwrapped values.
+///
+/// This iterator is intended for uses where it is resonable to abort the
+/// program if an error is encountered.
+///
+pub struct AbortingIter<I, V, E>(I)
+    where I: Iterator<Item = Result<V, E>> + Sized;
+
+impl<I, V, E> From<I> for AbortingIter<I, V, E>
+    where I: Iterator<Item = Result<V, E>> + Sized
+{
+    fn from(iter: I) -> Self {
+        AbortingIter(iter)
+    }
+}
+
+impl<I, V, E> Iterator for AbortingIter<I, V, E>
+    where I: Iterator<Item = Result<V, E>> + Sized,
+          E: Debug
+{
+    type Item = V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|next|
+            next.unwrap_or_else(|e| {
+                error!("{:?}", e);
+                exit(1)
+            })
+        )
+    }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@
 extern crate git2;
 extern crate libgitdit;
 
+mod abort;
 mod error;
 mod programs;
 mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use std::io::{self, BufRead, BufReader, Read, Write};
 use std::path::PathBuf;
 use std::process::Command;
 
+use abort::IteratorExt;
 use error::ErrorKind as EK;
 use error::*;
 use util::{RepositoryUtil, message_from_args};
@@ -65,11 +66,7 @@ fn check_message(matches: &clap::ArgMatches) -> i32 {
         None            => Box::from(io::stdin()),
     };
     BufReader::new(reader).lines()
-                          .map(|l| l.unwrap_or_else(|err| {
-                              // abort on IO errors
-                              error!("{:?}", err);
-                              std::process::exit(1);
-                          }))
+                          .abort_on_err()
                           .skip_while(|l| l.is_empty())
                           .stripped()
                           .check_message_format()

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,9 +13,9 @@ use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
 use std::path::PathBuf;
-use std::process::exit;
 use std::str::FromStr;
 
+use abort::IteratorExt;
 use error::ErrorKind as EK;
 use error::*;
 use programs::run_editor;
@@ -101,11 +101,7 @@ impl<'r> RepositoryUtil<'r> for Repository {
         // read the message back, check for validity
         let lines : Vec<String> = BufReader::new(File::open(path).chain_err(|| EK::WrappedIOError)?)
             .lines()
-            .map(|l| l.unwrap_or_else(|err| {
-                // abort on IO errors
-                error!("{:?}", err);
-                exit(1);
-            }))
+            .abort_on_err()
             .stripped()
             .collect();
 


### PR DESCRIPTION
This PR introduces a small utility for simplifying the handling of `Iterator<Result>` types.