### PR TITLE
Fix command line

### DIFF
--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -271,6 +271,7 @@ subcommands:
                 help: Message to which to reply to
                 index: 1
                 multiple: false
+                required: true
 
     - show:
         about: This uses 'git log' to print the issues.

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -106,20 +106,22 @@ subcommands:
             - Julian Ganz <neither@nut.email>
         args:
             - known:
+                short: k
                 help: also fetch known issues (those which visible through git dit list)
                 takes_value: false
                 multiple: false
             - prune:
+                short: p
                 help: Prune (as with git fetch)
                 takes_value: false
                 multiple: false
             - remote:
                 help: Remote to fetch from
-                index: 3
+                index: 1
                 multiple: false
             - issue:
                 help: Issue to fetch
-                index: 4
+                index: 2
                 multiple: true
 
     - list:

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -165,6 +165,7 @@ subcommands:
                         Use this as issue message. If used multiple times, each
                         argument will be a paragraph in the commit message.
                 multiple: true
+                number_of_values: 1
                 takes_value: true
             - signoff:
                 short: s
@@ -199,6 +200,7 @@ subcommands:
                         where <value> is the desired new value to set.
                         Passing an empty value leaves the metadata empty.
                 multiple: true
+                number_of_values: 1
                 takes_value: true
                 value_names:
                     - data
@@ -233,6 +235,7 @@ subcommands:
                 long: message
                 help: Use this as issue message
                 multiple: true
+                number_of_values: 1
                 takes_value: true
             - signoff:
                 short: s
@@ -264,6 +267,7 @@ subcommands:
                 long: reference
                 help: Reference a commit or message in the new message
                 multiple: true
+                number_of_values: 1
                 takes_value: true
                 value_names:
                     - commithash
@@ -372,6 +376,7 @@ subcommands:
                 long: reference
                 help: Reference a commit or message in the new message
                 multiple: true
+                number_of_values: 1
                 takes_value: true
                 value_names:
                     - commithash

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -286,13 +286,9 @@ subcommands:
             - Matthias Beyer <mail@beyermatthias.de>
             - Julian Ganz <neither@nut.email>
         args:
-            - parent:
-                help: Parent
+            - issue:
+                help: Issue to show
                 index: 1
-                multiple: false
-            - tree-init-hash:
-                help: Tree init hash
-                index: 2
                 multiple: false
             - abbrev:
                 short: a

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,7 @@ fn reply_impl(repo: &Repository, matches: &clap::ArgMatches) -> i32 {
     let issue = try_or_1!(repo.find_tree_init(&parent)).id();
 
     // get the references specified on the command line
-    let references = match matches.values_of("parents")
+    let references = match matches.values_of("reference")
                                .map(|p| repo.values_to_hashes(p)) {
         Some(hashes) => try_or_1!(hashes),
         _            => Vec::new(),


### PR DESCRIPTION
There are multiple issues with the `src/cli.yaml`. Some settings are wrong, so are some strings in the source. We should have checked them earlier. This PR is intended for cleaning up the mess that we shouldn't have produced in the first place.

Most notably, the `multiple` setting for options appears to make clap account any argument following the option, until the next one starting with a dash `-`, to the option, even if a required parameter is to be expected. As a work-around, one can insert a `--`, but the behaviour is not what one wants and confusing to users, imo.