### PR TITLE
Catch empty subcommands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -433,6 +433,7 @@ fn main() {
         ("reply",   Some(sub_matches)) => reply_impl(&repo, sub_matches),
         ("tag",     Some(sub_matches)) => tag_impl(&repo, sub_matches),
         // Unknown subcommands
+        ("", _) => { writeln!(io::stderr(), "{}", matches.usage()).ok(); 1 },
         (name, sub_matches) => {
             let default = clap::ArgMatches::default();
             handle_unknown_subcommand(name, sub_matches.unwrap_or(&default))


### PR DESCRIPTION
If we don't catch empty subcommands, we end up with
`handle_unknown_subcommand()` trying to invoke a program named
`git-dit-`. This, in turn, results in a "No such file or directory"
error, which is not especially useful for the user.

This PR solves the issue. Empty subcommands are handled by printing
the usage to stderr.