### PR TITLE
Enable old rustc versions on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ rust:
   - stable
   - beta
   - nightly
+  - 1.13.0
+  - 1.14.0
+  - 1.15.0
+  - 1.16.0
 matrix:
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: rust
 rust:
+  - 1.15.0
+  - 1.16.0
   - stable
   - beta
   - nightly
-  - 1.13.0
-  - 1.14.0
-  - 1.15.0
-  - 1.16.0
 matrix:
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
The reason for this is that some distributions are rather old for shipping updates here and (as far as I know by now) we can compile this with old versions.

If something breaks in an old version, we can fix is before the PR lands, as far as it is not too complicated to fix. Of course, the current version(s) of the rust compiler are prefered, but in most situations fixing the codebase for older versions won't hurt that much and the benefits are clearly more important than the draw-backs.

---

But before everything we should see whether this succeeds.