### PR TITLE
Make Cargo build the manpage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ addons:
     packages:
       - cmake
       - cmake-data
+      - pandoc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>",
            "Julian Ganz <neither@nut.email>"]
 
+build = "mkmanpage.rs"
+
 [workspace]
 members = [
     "lib"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,0 @@
-PANDOC=$(shell which pandoc)
-
-all: man
-
-man:
-	@$(PANDOC) -s -t man git-dit.1.md -o git-dit.1
-

--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ git-dit - the distributed issue tracker for git
 When playing with this, please keep in mind that this is alpha quality - there
 are bugs, missing things and rough edges.
 
+# Dependencies
+
+The following crates are used:
+* chrono 0.3
+* error-chain 0.10
+* git2 0.6
+* is-match 0.1
+* log 0.3
+
+Additionally, for building the man page, `pandoc` is required.
+
+
 # Installing
 
 _TBD_

--- a/mkmanpage.rs
+++ b/mkmanpage.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+
+fn main() {
+    assert!(Command::new("pandoc")
+        .arg("-s")
+        .arg("-t").arg("man")
+        .arg("git-dit.1.md")
+        .arg("-o").arg("git-dit.1")
+        .status()
+        .unwrap()
+        .success())
+}
+


### PR DESCRIPTION
This PR makes Cargo build the man page for us. The installation is, however, not performed. Since the `Makefile` was only introduced in order to build the man page, it was removed.
Resolves #92 and #93.