### PR TITLE
Execute buildscript only if desired

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ addons:
       - cmake
       - cmake-data
       - pandoc
+env:
+  - BUILD_GIT_DIT_MAN=1

--- a/mkmanpage.rs
+++ b/mkmanpage.rs
@@ -1,13 +1,15 @@
 use std::process::Command;
 
 fn main() {
-    assert!(Command::new("pandoc")
-        .arg("-s")
-        .arg("-t").arg("man")
-        .arg("git-dit.1.md")
-        .arg("-o").arg("git-dit.1")
-        .status()
-        .unwrap()
-        .success())
+    if std::env::var("BUILD_GIT_DIT_MAN").is_ok() {
+        assert!(Command::new("pandoc")
+            .arg("-s")
+            .arg("-t").arg("man")
+            .arg("git-dit.1.md")
+            .arg("-o").arg("git-dit.1")
+            .status()
+            .unwrap()
+            .success())
+    }
 }
 


### PR DESCRIPTION
The problem is that I don't want to install pandoc for development... and we cannot expect the casual hacker to do this, either.

So we make this dependend on a env variable. At least this is what I propose.