### PR TITLE
Rethink message creation

### DIFF
--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -15,6 +15,11 @@ error_chain! {
     }
 
     errors {
+        CannotCreateMessage {
+            description("Cannot create message")
+            display("Cannot create a message")
+        }
+
         CannotGetCommit {
             description("Cannot get a commit from the repository")
             display("Cannot get a specific commit from repository")

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -50,6 +50,11 @@ error_chain! {
             display("Cannot find issue HEAD for {}", id)
         }
 
+        CannotSetReference(refname: String) {
+            description("Cannot set some reference")
+            display("Cannot update or create reference '{}'", refname)
+        }
+
         NoTreeInitFound(id: Oid) {
             description("Cannot find any tree init")
             display("Cannot find any tree init for {}", id)

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -12,7 +12,7 @@
 //! This module provides the `Issue` type and related functionality.
 //!
 
-use git2::{self, Oid, Reference, References};
+use git2::{self, Commit, Oid, Reference, References};
 use std::fmt;
 use std::result::Result as RResult;
 

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -142,6 +142,18 @@ impl<'r> Issue<'r> {
             .chain_err(|| EK::CannotSetReference(refname))
     }
 
+    /// Add a new leaf reference associated with the issue
+    ///
+    /// Creates a new leaf reference for the message provided in the issue.
+    ///
+    pub fn add_leaf(&self, message: Oid) -> Result<Reference> {
+        let refname = format!("refs/dit/{}/leaves/{}", self.ref_part(), message);
+        let reflogmsg = format!("git-dit: new leaf for {}: {}", self, message);
+        self.repo
+            .reference(&refname, message, false, &reflogmsg)
+            .chain_err(|| EK::CannotSetReference(refname))
+    }
+
     /// Get reference part for this issue
     ///
     /// The references associated with an issue reside in paths specific to the

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -125,6 +125,23 @@ impl<'r> Issue<'r> {
             .chain_err(|| EK::CannotGetReferences(glob))
     }
 
+    /// Update the local head reference of the issue
+    ///
+    /// Updates the local head reference of the issue to the provided message.
+    ///
+    /// # Warnings
+    ///
+    /// The function will update the reference even if it would not be an
+    /// fast-forward update.
+    ///
+    pub fn update_head(&self, message: Oid) -> Result<Reference> {
+        let refname = format!("refs/dit/{}/head", self.ref_part());
+        let reflogmsg = format!("git-dit: set head reference of {} to {}", self, message);
+        self.repo
+            .reference(&refname, message, true, &reflogmsg)
+            .chain_err(|| EK::CannotSetReference(refname))
+    }
+
     /// Get reference part for this issue
     ///
     /// The references associated with an issue reside in paths specific to the

--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -73,23 +73,6 @@ pub trait RepositoryExt {
               I: IntoIterator<Item = &'a Commit<'a>, IntoIter = J>,
               J: Iterator<Item = &'a Commit<'a>>;
 
-    /// Create a new message
-    ///
-    /// This function creates a new issue message as well as an appropriate
-    /// reference. The oid of the new message will be returned.
-    /// The message will be part of the issue supplied by the caller. If no
-    /// issue is provided, a new issue will be initiated with the message.
-    /// In this case, the oid returned is also the oid of the new issue.
-    ///
-    fn create_message(&self,
-                      issue: Option<&Oid>,
-                      author: &Signature,
-                      committer: &Signature,
-                      message: &str,
-                      tree: &Tree,
-                      parents: &[&Commit]
-                     ) -> Result<Oid>;
-
     /// Get an revwalk configured as a first parent iterator
     ///
     /// This is a convenience function. It returns an iterator over messages in
@@ -190,28 +173,6 @@ impl RepositoryExt for Repository {
                 issue.update_head(issue.id())?;
                 Ok(issue)
             })
-    }
-
-    fn create_message(&self,
-                      issue: Option<&Oid>,
-                      author: &Signature,
-                      committer: &Signature,
-                      message: &str,
-                      tree: &Tree,
-                      parents: &[&Commit]
-                     ) -> Result<Oid> {
-        // commit message
-        let msg_id = try!(self.commit(None, author, committer, message, tree, parents));
-
-        // make an apropriate reference
-        let refname =  match issue {
-            Some(hash)  => format!("refs/dit/{}/leaves/{}", hash, msg_id),
-            _           => format!("refs/dit/{}/head", msg_id),
-        };
-        let reflogmsg = format!("new dit message: {}", msg_id);
-        try!(self.reference(&refname, msg_id, false, &reflogmsg));
-
-        Ok(msg_id)
     }
 
     fn first_parent_revwalk(&self, id: Oid) -> Result<git2::Revwalk> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,7 +323,7 @@ fn reply_impl(repo: &Repository, matches: &clap::ArgMatches) {
     let tree = parent.tree().unwrap_or_abort();
 
     // figure out to what issue we reply
-    let issue = repo.issue_with_message(&parent).unwrap_or_abort().id();
+    let issue = repo.issue_with_message(&parent).unwrap_or_abort();
 
     // get the references specified on the command line
     let references = repo.cli_references(matches).unwrap_or_abort();
@@ -368,11 +368,11 @@ fn reply_impl(repo: &Repository, matches: &clap::ArgMatches) {
     }.into_iter().collect_string();
 
     // construct a vector holding all parents
-    let parent_refs : Vec<&Commit> = Some(&parent).into_iter().chain(references.iter()).collect();
+    let parent_refs = Some(&parent).into_iter().chain(references.iter());
 
     // finally, create the message
-    repo.create_message(Some(&issue), &sig, &sig, message.trim(), &tree, &parent_refs)
-        .unwrap_or_abort();
+    issue.add_message(&sig, &sig, message.trim(), &tree, parent_refs)
+         .unwrap_or_abort();
 }
 
 /// show subcommand implementation

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,8 +257,9 @@ fn new_impl(repo: &Repository, matches: &clap::ArgMatches) {
 
     // commit the message
     let tree = repo.empty_tree().unwrap_or_abort();
-    let parent_refs = Vec::new();
-    let id = repo.create_message(None, &sig, &sig, message.trim(), &tree, &parent_refs).unwrap_or_abort();
+    let id = repo
+        .create_issue(&sig, &sig, message.trim(), &tree, Vec::new())
+        .unwrap_or_abort();
     println!("[dit][new] {}", id);
 }
 


### PR DESCRIPTION
`repository::RepositoryExt::create_message()` is a function doing to some extent two different things, dependent on the `issue` parameter. That parameter still is an `Oid` despite the new `Issue` type (well, I simply forgot about it). In this PR, we rethink the `create_message()` interface.

I'd like to replace `create_message()` completely. However, I'm not yet sure with what to replace it. Suggestions are welcome.