### PR TITLE
Don't make the CI build for old rust-vresions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: rust
 rust:
-  - 1.15.0
-  - 1.16.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
Apparently, some dependencies don't care about old rust-versions. Hence,
supporting those old versions doesn't make sense.