### PR TITLE
Redefine retrieval of issue references 

### DIFF
--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -66,7 +66,7 @@ impl<'r> Issue<'r> {
     /// Returns the head reference of the issue from the local repository, if
     /// present.
     ///
-    pub fn find_local_head(&self) -> Result<Reference<'r>> {
+    pub fn local_head(&self) -> Result<Reference<'r>> {
         let refname = format!("refs/dit/{}/head", self.ref_part());
         self.repo
             .find_reference(&refname)

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -92,18 +92,6 @@ impl<'r> Issue<'r> {
             .chain_err(|| EK::CannotFindIssueHead(self.id))
     }
 
-    /// Get the leaf references for the issue
-    ///
-    /// Returns the leaf references for the issue from both the local repository
-    /// and remotes.
-    ///
-    pub fn issue_leaves(&self) -> Result<References<'r>> {
-        let glob = format!("**/dit/{}/leaves/*", self.ref_part());
-        self.repo
-            .references_glob(&glob)
-            .chain_err(|| EK::CannotGetReferences(glob))
-    }
-
     /// Get local references for the issue
     ///
     /// Return all references of a specific type associated with the issue from

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -273,7 +273,7 @@ mod tests {
             .expect("Could not add message");
 
         let mut leaves = issue
-            .issue_leaves()
+            .local_refs(IssueRefType::Leaf)
             .expect("Could not retrieve issue leaves");
         let leaf = leaves
             .next()
@@ -321,7 +321,7 @@ mod tests {
         let mut ids = vec![issue.id(), message.id()];
         ids.sort();
         let mut ref_ids: Vec<Oid> = issue
-            .local_refs()
+            .local_refs(IssueRefType::Any)
             .expect("Could not retrieve local refs")
             .map(|reference| reference.unwrap().target().unwrap())
             .collect();
@@ -393,12 +393,12 @@ mod tests {
             .add_message(&sig, &sig, "Test message 3", &empty_tree, vec![&initial_message])
             .expect("Could not add message");
 
-        assert_eq!(issue.find_local_head().unwrap().target().unwrap(), issue.id());
+        assert_eq!(issue.local_head().unwrap().target().unwrap(), issue.id());
 
         issue
             .update_head(message.id())
             .expect("Could not update head reference");
-        assert_eq!(issue.find_local_head().unwrap().target().unwrap(), message.id());
+        assert_eq!(issue.local_head().unwrap().target().unwrap(), message.id());
     }
 }
 

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -116,6 +116,18 @@ impl<'r> Issue<'r> {
             .chain_err(|| EK::CannotGetReferences(glob))
     }
 
+    /// Get remote references for the issue
+    ///
+    /// Return all references of a specific type associated with the issue from
+    /// all remote repositories.
+    ///
+    pub fn remote_refs(&self, ref_type: IssueRefType) -> Result<References<'r>> {
+        let glob = format!("refs/remotes/*/dit/{}/{}", self.ref_part(), ref_type.glob_part());
+        self.repo
+            .references_glob(&glob)
+            .chain_err(|| EK::CannotGetReferences(glob))
+    }
+
     /// Get a revwalk for traversing all messages of the issue
     ///
     /// The sorting of the revwalk will be set to "topological".

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -128,6 +128,18 @@ impl<'r> Issue<'r> {
             .chain_err(|| EK::CannotGetReferences(glob))
     }
 
+    /// Get references for the issue
+    ///
+    /// Return all references of a specific type associated with the issue from
+    /// both the local and remote repositories.
+    ///
+    pub fn all_refs(&self, ref_type: IssueRefType) -> Result<References<'r>> {
+        let glob = format!("**/dit/{}/{}", self.ref_part(), ref_type.glob_part());
+        self.repo
+            .references_glob(&glob)
+            .chain_err(|| EK::CannotGetReferences(glob))
+    }
+
     /// Get a revwalk for traversing all messages of the issue
     ///
     /// The sorting of the revwalk will be set to "topological".

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -20,6 +20,25 @@ use error::*;
 use error::ErrorKind as EK;
 
 
+pub enum IssueRefType {
+    Any,
+    Head,
+    Leaf,
+}
+
+impl IssueRefType {
+    /// Get the part of a glob specific to the type
+    ///
+    pub fn glob_part(&self) -> &'static str {
+        match *self {
+            IssueRefType::Any   => "**",
+            IssueRefType::Head  => "head",
+            IssueRefType::Leaf  => "leaves/*",
+        }
+    }
+}
+
+
 /// Issue handle
 ///
 /// Instances of this type represent single issues. Issues reside in

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -104,13 +104,13 @@ impl<'r> Issue<'r> {
             .chain_err(|| EK::CannotGetReferences(glob))
     }
 
-    /// Get all local references for the issue
+    /// Get local references for the issue
     ///
-    /// Return all references associated with the issue from the local
-    /// repository.
+    /// Return all references of a specific type associated with the issue from
+    /// the local repository.
     ///
-    pub fn local_refs(&self) -> Result<References<'r>> {
-        let glob = format!("refs/dit/{}/**", self.ref_part());
+    pub fn local_refs(&self, ref_type: IssueRefType) -> Result<References<'r>> {
+        let glob = format!("refs/dit/{}/{}", self.ref_part(), ref_type.glob_part());
         self.repo
             .references_glob(&glob)
             .chain_err(|| EK::CannotGetReferences(glob))

--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -241,7 +241,7 @@ mod tests {
             .expect("Could not create issue");
 
         let local_head = issue
-            .find_local_head()
+            .local_head()
             .expect("Could not retrieve local head reference");
         let retrieved_issue = repo
             .issue_by_head_ref(&local_head)

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod write;
 use chrono::{FixedOffset, TimeZone};
 use clap::App;
 use git2::{Commit, Repository};
+use libgitdit::issue::IssueRefType;
 use libgitdit::message::{LineIteratorExt, Trailer};
 use libgitdit::{Message, RemoteExt, RepositoryExt};
 use log::LogLevel;
@@ -281,7 +282,7 @@ fn push_impl(repo: &Repository, matches: &clap::ArgMatches) {
         // push a specific list of issues
         issues.map(|issue| repo.value_to_issue(issue))
               .abort_on_err()
-              .map(|issue| issue.local_refs())
+              .map(|issue| issue.local_refs(IssueRefType::Any))
               .abort_on_err()
               .flat_map(git2::References::names)
               .abort_on_err()
@@ -290,7 +291,7 @@ fn push_impl(repo: &Repository, matches: &clap::ArgMatches) {
     } else {
         repo.issues_with_prefix("refs")
             .abort_on_err()
-            .map(|issue| issue.local_refs())
+            .map(|issue| issue.local_refs(IssueRefType::Any))
             .abort_on_err()
             .flat_map(git2::References::names)
             .abort_on_err()

--- a/src/main.rs
+++ b/src/main.rs
@@ -474,7 +474,7 @@ fn tag_impl(repo: &Repository, matches: &clap::ArgMatches) {
     let mut issue_head = repo
         .cli_issue(matches)
         .unwrap_or_abort()
-        .find_local_head()
+        .local_head()
         .unwrap_or_abort();
     let mut head_commit = issue_head
         .peel(git2::ObjectType::Commit)


### PR DESCRIPTION
This PR aims at streamlining and redefining the methods for retrieval of issue references.
It contains breaking changes.
Block #117.