### PR TITLE
Add missing metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "git-dit"
 version = "0.2.1"
+description = "A CLI frontend for libgitdit - a distributed issue tracker"
 authors = ["Matthias Beyer <mail@beyermatthias.de>",
            "Julian Ganz <neither@nut.email>"]
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "libgitdit"
 version = "0.2.1"
+description = "A library for distributed issue tracking in git"
 authors = ["Matthias Beyer <mail@beyermatthias.de>",
            "Julian Ganz <neither@nut.email>"]
 


### PR DESCRIPTION
Add missing crate meta information.

Because of this we cannot publish 0.2.0 and 0.2.1 on crates.io.