### PR TITLE
Determination of dit reference type

### DIFF
--- a/git-dit.1.md
+++ b/git-dit.1.md
@@ -67,6 +67,9 @@ and low level ("plumbing") commands.
 ## git-dit-check-message
     Check whether the format of an issue message is valid.
 
+## git-dit-check-refname
+    Check whether a reference is a dit reference of a known type, by name.
+
 ## git-dit-create-message
     Create a bare message.
 

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -91,6 +91,16 @@ impl IssueRefType {
     }
 }
 
+impl fmt::Debug for IssueRefType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> RResult<(), fmt::Error> {
+        f.write_str(match self {
+            &IssueRefType::Any   => "Any ref",
+            &IssueRefType::Head  => "Head ref",
+            &IssueRefType::Leaf  => "Leaf ref",
+        })
+    }
+}
+
 
 /// Issue handle
 ///

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -300,6 +300,32 @@ mod tests {
 
     use repository::RepositoryExt;
 
+    // IssueRefType tests
+
+    #[test]
+    fn ref_identification() {
+        {
+            let (id, reftype) = IssueRefType::of_ref("refs/dit/65b56706fdc3501749d008750c61a1f24b888f72/head")
+                .expect("Expected valid issue id and ref type");
+            assert_eq!(id.to_string(), "65b56706fdc3501749d008750c61a1f24b888f72");
+            assert_eq!(reftype, IssueRefType::Head);
+        }
+        {
+            let (id, reftype) = IssueRefType::of_ref("refs/dit/65b56706fdc3501749d008750c61a1f24b888f72/leaves/f6bd121bdc2ba5906e412da19191a2eaf2025755")
+                .expect("Expected valid issue id and ref type");
+            assert_eq!(id.to_string(), "65b56706fdc3501749d008750c61a1f24b888f72");
+            assert_eq!(reftype, IssueRefType::Leaf);
+        }
+
+        assert!(IssueRefType::of_ref("refs/dit/65b56706fdc3501749d008750c61a1f24b888f72/foo/f6bd121bdc2ba5906e412da19191a2eaf2025755").is_none());
+        assert!(IssueRefType::of_ref("refs/dit/65b56706fdc3501749d008750c61a1f24b888f72/head/foo").is_none());
+        assert!(IssueRefType::of_ref("refs/dit/65b56706fdc3501749d008750c61a1f24b888f72/leaves/foo").is_none());
+        assert!(IssueRefType::of_ref("refs/dit/foo/leaves/f6bd121bdc2ba5906e412da19191a2eaf2025755").is_none());
+        assert!(IssueRefType::of_ref("refs/dit/foo/head").is_none());
+        assert!(IssueRefType::of_ref("refs/foo/65b56706fdc3501749d008750c61a1f24b888f72/head").is_none());
+        assert!(IssueRefType::of_ref("refs/foo/65b56706fdc3501749d008750c61a1f24b888f72/leaves/f6bd121bdc2ba5906e412da19191a2eaf2025755").is_none());
+    }
+
     // Issue tests
 
     #[test]

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -20,6 +20,7 @@ use error::*;
 use error::ErrorKind as EK;
 
 
+#[derive(PartialEq)]
 pub enum IssueRefType {
     Any,
     Head,

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -34,6 +34,31 @@ subcommands:
                 takes_value: true
                 multiple: false
 
+    - check-refname:
+        about: Checks whether a reference is a dit reference of a known type, by name
+        version: 0.2.1
+        authors:
+            - Matthias Beyer <mail@beyermatthias.de>
+            - Julian Ganz <neither@nut.email>
+        args:
+            - refname:
+                help: Reference name to check
+                index: 1
+                required: true
+                multiple: false
+            - issue-id:
+                short: i
+                long: issue-id
+                help: Print the id of the (supposed) issue corresponding to the reference
+                multiple: false
+                takes_value: false
+            - reftype:
+                short: t
+                long: reftype
+                help: Print the type of reference (e.g. "head" or "leaf")
+                multiple: false
+                takes_value: false
+
     - create-message:
         about: >
                  Create a new message. The parents provided will be the parents of the new

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,31 @@ fn check_message(matches: &clap::ArgMatches) {
 }
 
 
+/// check-message subcommand implementation
+///
+fn check_refname(matches: &clap::ArgMatches) {
+    // NOTE: check-refname is always present since it is a required parameter
+    let refdata = IssueRefType::of_ref(matches.value_of("refname").unwrap());
+    if let Some((id, reftype)) = refdata {
+        // The reference is a valid dit reference. We may now answer questions
+        // about it.
+        if matches.is_present("issue-id") {
+            println!("{}", id);
+        }
+        if matches.is_present("reftype") {
+            println!("{}", match reftype {
+                IssueRefType::Head => "head",
+                IssueRefType::Leaf => "leaf",
+                _ => "unknown",
+            });
+        }
+    } else {
+        use std::process::exit;
+        exit(1);
+    }
+}
+
+
 /// create-message subcommand implementation
 ///
 fn create_message(repo: &Repository, matches: &clap::ArgMatches) {
@@ -585,6 +610,7 @@ fn main() {
     match matches.subcommand() {
         // Plumbing subcommands
         ("check-message",               Some(sub_matches)) => check_message(sub_matches),
+        ("check-refname",               Some(sub_matches)) => check_refname(sub_matches),
         ("create-message",              Some(sub_matches)) => create_message(&repo, sub_matches),
         ("find-tree-init-hash",         Some(sub_matches)) => find_tree_init_hash(&repo, sub_matches),
         ("get-issue-metadata",          Some(sub_matches)) => get_issue_metadata(&repo, sub_matches),


### PR DESCRIPTION
Authors of git server hooks (e.g. `update` hooks) may want to determine
of what type a given dit reference and whether it is a dit reference at
all.