### PR TITLE
Remote priorization

### DIFF
--- a/git-dit.1.md
+++ b/git-dit.1.md
@@ -116,6 +116,20 @@ acceptance of some discussion point.
 
 The following git-dit-specific configuration options are available:
 
+## dit.remote-prios
+
+Comma-separated list of remotes' names, in descending order of priority.
+This option controls the prioritization of remotes.
+
+Some commands may use this option in order to select one of several available
+remote references for processing.
+For example, commands which accumulate metadata for an issue may automatically
+select one of the visible "head" references for that issue.
+
+In such cases, local references will always be preferred before remote
+references are considered.
+Remotes not listed are assigned the lowest possible priority.
+
 
 # WORKFLOWS
 

--- a/git-dit.1.md
+++ b/git-dit.1.md
@@ -112,6 +112,11 @@ Additionally, a maintainer may use the "head" reference to communicate
 acceptance of some discussion point.
 
 
+# CONFIGURATION
+
+The following git-dit-specific configuration options are available:
+
+
 # WORKFLOWS
 
 Git-dit tries not to force a specific work-flow on its users.

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod error;
 mod logger;
 mod msgtree;
 mod programs;
+mod reference;
 mod util;
 mod write;
 

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -8,6 +8,7 @@
 //
 
 use git2::Reference;
+use std::borrow::Borrow;
 
 
 /// Extension trait for references
@@ -82,3 +83,20 @@ impl<'a> From<&'a str> for RemotePriorization {
     }
 }
 
+
+/// Extension trait for iterators over references
+///
+pub trait ReferrencesExt<'r> {
+    /// Select the reference with the highest priority
+    ///
+    fn select_ref(self, prios: RemotePriorization) -> Option<Reference<'r>>;
+}
+
+impl<'r, I> ReferrencesExt<'r> for I
+    where I: IntoIterator<Item = Reference<'r>>,
+{
+    fn select_ref(self, prios: RemotePriorization) -> Option<Reference<'r>> {
+        self.into_iter()
+            .min_by_key(|reference| prios.priority_for_ref(reference.borrow()))
+    }
+}

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -1,0 +1,42 @@
+//   git-dit - the distributed issue tracker for git
+//   Copyright (C) 2017 Matthias Beyer <mail@beyermatthias.de>
+//   Copyright (C) 2017 Julian Ganz <neither@nut.email>
+//
+//   This program is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License version 2 as
+//   published by the Free Software Foundation.
+//
+
+use git2::Reference;
+
+
+/// Extension trait for references
+///
+pub trait ReferrenceExt {
+    /// Get the name of the remote associated with the reference
+    ///
+    /// If this reference is a remote trackign ref, the name of the remote will
+    /// be returned. If the reference is not associated with any remote, the
+    /// function will return `None`.
+    ///
+    fn remote(&self) -> Option<&str>;
+}
+
+impl<'r> ReferrenceExt for Reference<'r> {
+    fn remote(&self) -> Option<&str> {
+        if let Some(name) = self.name() {
+            let mut name_parts = name.split('/');
+
+            if !is_match!(name_parts.next(), Some("refs")) {
+                return None
+            }
+            if !is_match!(name_parts.next(), Some("remotes")) {
+                return None
+            }
+            name_parts.next()
+        } else {
+            None
+        }
+    }
+}
+

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -40,3 +40,45 @@ impl<'r> ReferrenceExt for Reference<'r> {
     }
 }
 
+
+/// Expression of priorization of remotes
+///
+/// Use this type for querying the priority of a remote, represented as a
+/// numerical value. A lower numerical value indicates a higher priority.
+///
+pub struct RemotePriorization(Vec<String>);
+
+impl RemotePriorization {
+    /// Query the priority for a remote
+    ///
+    /// If the remote's name is not found, the lowest possible priority is
+    /// returned.
+    ///
+    pub fn priority_for_remote(&self, remote: &str) -> usize {
+        self.0
+            .iter()
+            .position(|item| *item == remote)
+            .map(|pos| pos + 1)
+            .unwrap_or(usize::max_value())
+    }
+
+    /// Query the priority of a reference
+    ///
+    /// This function returns the priority of the remote assiciated with a
+    /// reference. If the reference does not appear to be a remote, the highest
+    /// possible priority is returned.
+    ///
+    pub fn priority_for_ref(&self, reference: &Reference) -> usize {
+        reference
+            .remote()
+            .map(|name| self.priority_for_remote(name))
+            .unwrap_or(0)
+    }
+}
+
+impl<'a> From<&'a str> for RemotePriorization {
+    fn from(list: &'a str) -> Self {
+        RemotePriorization(list.split(',').map(String::from).collect())
+    }
+}
+

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,13 +14,15 @@ use std::io;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use abort::IteratorExt;
-use error::ErrorKind as EK;
-use error::*;
-use programs::run_editor;
-use libgitdit::{Issue, RepositoryExt};
 use libgitdit::message::LineIteratorExt;
 use libgitdit::message::trailer::Trailer;
+use libgitdit::{Issue, RepositoryExt};
+
+use abort::IteratorExt;
+use error::*;
+use error::ErrorKind as EK;
+use programs::run_editor;
+use reference::RemotePriorization;
 
 /// Open the DIT repo
 ///
@@ -86,6 +88,9 @@ pub trait RepositoryUtil<'r> {
     /// Get the abbreviation length for oids
     ///
     fn abbreviation_length(&self, matches: &ArgMatches) -> Result<usize>;
+
+    /// Get remote priorization from the config
+    fn remote_priorization(&self) -> Result<RemotePriorization>;
 }
 
 impl<'r> RepositoryUtil<'r> for Repository {
@@ -196,6 +201,13 @@ impl<'r> RepositoryUtil<'r> for Repository {
 
         // TODO: use a larger number based on the number of objects in the repo
         Ok(7)
+    }
+
+    fn remote_priorization(&self) -> Result<RemotePriorization> {
+        let config = self
+            .config()
+            .chain_err(|| EK::CannotGetRepositoryConfig)?;
+        Ok(RemotePriorization::from(config.get_str("dit.remote-prios").unwrap_or_default()))
     }
 }
 


### PR DESCRIPTION
Currently, all references available for an issue are treated equally in some regards. For example, when querying the metadata, the next best head-reference is used. This behaviour is not optimal, especially in the light of multiple remotes and upcoming functionality.
