### PR TITLE
Consolidate message iteration

### DIFF
--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -20,6 +20,11 @@ error_chain! {
             display("Cannot create a message")
         }
 
+        CannotConstructRevwalk {
+            description("Cannot construct revwalk")
+            display("Cannot construct a revwalk for iterating over commits")
+        }
+
         CannotGetCommit {
             description("Cannot get a commit from the repository")
             display("Cannot get a specific commit from repository")

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -212,6 +212,23 @@ impl<'r> Issue<'r> {
             })
     }
 
+    /// Get Messages of the issue starting from a specific one
+    ///
+    /// The Messages iterator returned will return all first parents up to and
+    /// includingthe initial message of the issue.
+    ///
+    pub fn messages_from(&self, message: Oid) -> Result<Messages<'r>> {
+        self.terminated_messages()
+            .and_then(|mut messages| {
+                messages
+                    .revwalk
+                    .push(message)
+                    .chain_err(|| EK::CannotConstructRevwalk)?;
+
+                Ok(messages)
+            })
+    }
+
     /// Prepare a Messages iterator which will terminate at the initial message
     ///
     pub fn terminated_messages(&self) -> Result<Messages<'r>> {

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -197,7 +197,7 @@ impl<'r> Issue<'r> {
     /// The sorting of the underlying revwalk will be set to "topological".
     ///
     pub fn messages(&self) -> Result<Messages<'r>> {
-        Messages::empty(self.repo)
+        self.terminated_messages()
             .and_then(|mut messages| {
                 let glob = format!("**/dit/{}/**", self.ref_part());
 
@@ -207,6 +207,17 @@ impl<'r> Issue<'r> {
                     .revwalk
                     .push_glob(glob.as_ref())
                     .chain_err(|| EK::CannotGetReferences(glob))?;
+
+                Ok(messages)
+            })
+    }
+
+    /// Prepare a Messages iterator which will terminate at the initial message
+    ///
+    pub fn terminated_messages(&self) -> Result<Messages<'r>> {
+        Messages::empty(self.repo)
+            .and_then(|mut messages| {
+                // terminate at this issue's initial message
                 messages.terminate_at_initial(self)?;
 
                 // configure the revwalk

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -18,6 +18,7 @@ use std::result::Result as RResult;
 
 use error::*;
 use error::ErrorKind as EK;
+use iter::Messages;
 
 
 #[derive(PartialEq)]
@@ -191,32 +192,29 @@ impl<'r> Issue<'r> {
             .chain_err(|| EK::CannotGetReferences(glob))
     }
 
-    /// Get a revwalk for traversing all messages of the issue
+    /// Get all Messages of the issue
     ///
-    /// The sorting of the revwalk will be set to "topological".
+    /// The sorting of the underlying revwalk will be set to "topological".
     ///
-    pub fn message_revwalk(&self) -> Result<git2::Revwalk<'r>> {
-        let glob = format!("**/dit/{}/**", self.ref_part());
-        self.repo
-            .revwalk()
-            .and_then(|mut revwalk| {
+    pub fn messages(&self) -> Result<Messages<'r>> {
+        Messages::empty(self.repo)
+            .and_then(|mut messages| {
+                let glob = format!("**/dit/{}/**", self.ref_part());
+
                 // The iterator will iterate over all the messages in the tree
                 // spanned but it will halt at the initial message.
-                revwalk.push_glob(glob.as_ref())?;
-                let _ = self.repo
-                    .find_commit(self.id)
-                    .and_then(|commit| commit.parent_id(0))
-                    .ok() // the initial message having no parent is not unusual
-                    .map(|parent| revwalk.hide(parent))
-                    .unwrap_or(Ok(()))?;
+                messages
+                    .revwalk
+                    .push_glob(glob.as_ref())
+                    .chain_err(|| EK::CannotGetReferences(glob))?;
+                messages.terminate_at_initial(self)?;
 
                 // configure the revwalk
-                revwalk.simplify_first_parent();
-                revwalk.set_sorting(git2::SORT_TOPOLOGICAL);
+                messages.revwalk.simplify_first_parent();
+                messages.revwalk.set_sorting(git2::SORT_TOPOLOGICAL);
 
-                Ok(revwalk)
+                Ok(messages)
             })
-            .chain_err(|| EK::CannotGetReferences(glob))
     }
 
     /// Add a new message to the issue
@@ -448,16 +446,16 @@ mod tests {
         let message_id = message.id();
 
         let mut iter1 = issue1
-            .message_revwalk()
+            .messages()
             .expect("Could not create message revwalk iterator");
-        assert_eq!(iter1.next().unwrap().unwrap(), issue1.id());
+        assert_eq!(iter1.next().unwrap().unwrap().id(), issue1.id());
         assert!(iter1.next().is_none());
 
         let mut iter2 = issue2
-            .message_revwalk()
+            .messages()
             .expect("Could not create message revwalk iterator");
-        assert_eq!(iter2.next().unwrap().unwrap(), message_id);
-        assert_eq!(iter2.next().unwrap().unwrap(), issue2.id());
+        assert_eq!(iter2.next().unwrap().unwrap().id(), message_id);
+        assert_eq!(iter2.next().unwrap().unwrap().id(), issue2.id());
         assert!(iter2.next().is_none());
     }
 

--- a/lib/src/iter.rs
+++ b/lib/src/iter.rs
@@ -70,6 +70,12 @@ impl<'r> Messages<'r> {
     pub fn new<'a>(repo: &'a Repository, revwalk: git2::Revwalk<'a>) -> Messages<'a> {
         Messages { revwalk: revwalk, repo: repo }
     }
+
+    /// Create an IssueMessagesIter from this instance
+    ///
+    pub fn until_any_initial(self) -> IssueMessagesIter<'r> {
+        self.into()
+    }
 }
 
 impl<'r> Iterator for Messages<'r> {

--- a/lib/src/iter.rs
+++ b/lib/src/iter.rs
@@ -71,6 +71,14 @@ impl<'r> Messages<'r> {
         Messages { revwalk: revwalk, repo: repo }
     }
 
+    /// Create a new messages iter from an unconfigured revwalk
+    ///
+    pub fn empty<'a>(repo: &'a Repository) -> Result<Messages<'a>> {
+        repo.revwalk()
+            .map(|revwalk| Self::new(repo, revwalk))
+            .chain_err(|| EK::CannotConstructRevwalk)
+    }
+
     /// Create an IssueMessagesIter from this instance
     ///
     pub fn until_any_initial(self) -> IssueMessagesIter<'r> {

--- a/lib/src/iter.rs
+++ b/lib/src/iter.rs
@@ -109,6 +109,12 @@ impl<'r> IssueMessagesIter<'r> {
     }
 }
 
+impl<'r> From<Messages<'r>> for IssueMessagesIter<'r> {
+    fn from(messages: Messages<'r>) -> Self {
+        IssueMessagesIter(messages)
+    }
+}
+
 impl<'r> Iterator for IssueMessagesIter<'r> {
     type Item = Result<git2::Commit<'r>>;
 

--- a/lib/src/iter.rs
+++ b/lib/src/iter.rs
@@ -76,6 +76,19 @@ impl<'r> Messages<'r> {
     pub fn until_any_initial(self) -> IssueMessagesIter<'r> {
         self.into()
     }
+
+    /// Terminate this iterator at the given issue's initial message
+    ///
+    /// This method hides the initial message's parents. It is somewhat more
+    /// performant than creating an `IssueMessagesIter`. However, the issue has
+    /// to be known in advance.
+    ///
+    pub fn terminate_at_initial(&mut self, issue: &issue::Issue) -> Result<()> {
+        for parent in issue.initial_message()?.parent_ids() {
+            self.revwalk.hide(parent)?;
+        }
+        Ok(())
+    }
 }
 
 impl<'r> Iterator for Messages<'r> {

--- a/lib/src/iter.rs
+++ b/lib/src/iter.rs
@@ -121,12 +121,6 @@ impl<'r> Iterator for Messages<'r> {
 pub struct IssueMessagesIter<'r>(Messages<'r>);
 
 impl<'r> IssueMessagesIter<'r> {
-    pub fn new<'a>(repo: &'a Repository, commit: git2::Commit<'a>) -> Result<IssueMessagesIter<'a>> {
-        repo.first_parent_revwalk(commit.id())
-            .map(|revwalk| Messages::new(repo, revwalk))
-            .map(|messages| IssueMessagesIter(messages))
-    }
-
     /// Fuse the iterator is the id refers to an issue
     ///
     fn fuse_if_initial(&mut self, id: git2::Oid) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -492,9 +492,7 @@ fn show_impl(matches: &clap::ArgMatches) {
             )]
         } else {
             issue
-                .message_revwalk()
-                .abort_on_err()
-                .map(|oid| repo.find_commit(oid))
+                .messages()
                 .abort_on_err()
                 .into_tree_graph()
                 .collect()


### PR DESCRIPTION
Currently, we offer multiple iterators for iterating over messages. Sadly, most of those are isolated from each other. Additionally, we often provide only a `Revwalk` for general purpose usage when the goal is to iterate over messages.