### PR TITLE
Add an example update hook for realizing a dit-only policy

### DIFF
--- a/examples/hooks/update
+++ b/examples/hooks/update
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Copyright (C) 2017 Matthias Beyer <mail@beyermatthias.de>
+# Copyright (C) 2017 Julian Ganz <neither@nut.email>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the “Software”), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+#
+# Server side example update hook
+#
+# This hook may be used for realizing access control for issue repos with public
+# push-access. Commit signatures are used in order to prevent impersonation.
+# Removing references will generally not be allowed. New heads and leaves may be
+# pushed by users, but no non-dit references. Additionally, heads may be updated
+# by an assignee.
+#
+# Note that this hook lacks a general pass for administrators and moderators.
+# Also note that new head references may always be pushed, even if no initial
+# commit with a matching id exists.
+#
+
+
+die() {
+    echo "$*" >&2
+    exit 1
+}
+
+check_rogue() {
+    init_hash="$(git dit find-tree-init-hash "$newhash")"
+    [[ "$issue" == "$init_hash" ]] || die "The pushed ref appears to be a rougue hash"
+}
+
+zerohash='0000000000000000000000000000000000000000'
+
+
+# Retrieve input arguments
+refname="$1"
+oldhash="$2"
+newhash="$3"
+
+
+# Basic integrity checks
+[[ $newhash != "$zerohash" ]] || die "Users are not allowed to remove refs"
+git verify-commit "$newhash" || die "Messages must be signed"
+
+issue="$(git dit check-refname --issue-id "$refname")"
+
+
+# Reference type dependent access rules
+case "$(git dit check-refname --reftype "$refname")" in
+    head)
+        if [[ $oldhash != "$zerohash" ]]; then
+            check_rogue
+            assignee="$(git dit get-issue-metadata --key 'Dit-assignee' --latest "$oldhash" --values-only)"
+            author="$(git show -s --format='%an <%ae>' "$newhash")"
+            [[ "$assignee" == "$author" ]] || die "Only the assignee may update the head"
+        fi
+        ;;
+    leaf)
+        check_rogue
+        [[ "$oldhash" == "$zerohash" ]] || die "Updating of leaf references is not allowed"
+        ;;
+    *)
+        die "Only dit refs are allowed"
+        ;;
+esac
+


### PR DESCRIPTION
Server administrators may use the hook or parts of for dit-repositories
on their servers.