### PR TITLE
Subcommand for mirroring references

### DIFF
--- a/git-dit.1.md
+++ b/git-dit.1.md
@@ -61,6 +61,9 @@ and low level ("plumbing") commands.
 ## git-dit-push
     Push issues to a remote repository.
 
+## git-dit-mirror
+    Mirror remote references as local ones.
+
 ## git-dit-gc
     Collect and delete references which are no longer required.
 

--- a/lib/src/gc.rs
+++ b/lib/src/gc.rs
@@ -255,7 +255,7 @@ mod tests {
             let message = issue
                 .add_message(&sig, &sig, "Test message 4", &empty_tree, vec![&initial_message])
                 .expect("Could not add message");
-            issue.update_head(message.id()).expect("Could not update head");
+            issue.update_head(message.id(), true).expect("Could not update head");
             issues.push(issue);
             refs_to_collect.push(message.id());
         }

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -279,11 +279,11 @@ impl<'r> Issue<'r> {
     /// The function will update the reference even if it would not be an
     /// fast-forward update.
     ///
-    pub fn update_head(&self, message: Oid) -> Result<Reference<'r>> {
+    pub fn update_head(&self, message: Oid, replace: bool) -> Result<Reference<'r>> {
         let refname = format!("refs/dit/{}/head", self.ref_part());
         let reflogmsg = format!("git-dit: set head reference of {} to {}", self, message);
         self.repo
-            .reference(&refname, message, true, &reflogmsg)
+            .reference(&refname, message, replace, &reflogmsg)
             .chain_err(|| EK::CannotSetReference(refname))
     }
 
@@ -511,7 +511,7 @@ mod tests {
         assert_eq!(issue.local_head().unwrap().target().unwrap(), issue.id());
 
         issue
-            .update_head(message.id())
+            .update_head(message.id(), true)
             .expect("Could not update head reference");
         assert_eq!(issue.local_head().unwrap().target().unwrap(), message.id());
     }

--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -182,7 +182,7 @@ impl RepositoryExt for git2::Repository {
             .chain_err(|| EK::CannotCreateMessage)
             .map(|id| Issue::new(self, id))
             .and_then(|issue| {
-                issue.update_head(issue.id())?;
+                issue.update_head(issue.id(), true)?;
                 Ok(issue)
             })
     }

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -237,6 +237,55 @@ subcommands:
                 multiple: true
                 required: false
 
+    - mirror:
+        about: Clone issue references from remotes
+        version: 0.2.1
+        authors:
+            - Matthias Beyer <mail@beyermatthias.de>
+            - Julian Ganz <neither@nut.email>
+        groups:
+            - refs:
+                required: true
+                multiple: true
+                args:
+                    - clone-head
+                    - update-head
+                    - clone-leaves
+        args:
+            - clone-head:
+                short: H
+                long: head
+                help: >
+                        Clone the head reference if no local head exists for
+                        the issue
+                multiple: false
+                takes_value: false
+            - update-head:
+                short: u
+                long: update-head
+                help: Clone the head reference overriding existing head refs
+                multiple: false
+                takes_value: false
+                conflicts_with:
+                    - clone-head
+            - clone-leaves:
+                short: l
+                long: leaves
+                help: Create local leaves for the issue
+                multiple: false
+                takes_value: false
+            - remote:
+                short: r
+                long: remote
+                help: Only clone refs from the remote specified
+                multiple: false
+                takes_value: true
+            - issue:
+                help: Issue for which to clone refs
+                index: 1
+                required: false
+                multiple: true
+
     - new:
         about: Create a new bug report
         version: 0.2.1


### PR DESCRIPTION
Some actions which may be performed on an issue repository requires local references to be present. E.g. transferring issues between two remotes involves pushing the references to the target remote. However, only local references can be pushed. A solution would be to mirror the references from the source as local references for pushing.

This PR implements a subcommand for mirroring refs.