### PR TITLE
Redefine remote prioritization

### DIFF
--- a/git-dit.1.md
+++ b/git-dit.1.md
@@ -119,6 +119,7 @@ The following git-dit-specific configuration options are available:
 ## dit.remote-prios
 
 Comma-separated list of remotes' names, in descending order of priority.
+Defaults to "`*`".
 This option controls the prioritization of remotes.
 
 Some commands may use this option in order to select one of several available
@@ -128,7 +129,8 @@ select one of the visible "head" references for that issue.
 
 In such cases, local references will always be preferred before remote
 references are considered.
-Remotes not listed are assigned the lowest possible priority.
+Remotes not listed will be ignored. However, the special entry "`*`" will accept
+any remote.
 
 
 # WORKFLOWS

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -47,20 +47,20 @@ impl<'r> ReferrenceExt for Reference<'r> {
 /// Use this type for querying the priority of a remote, represented as a
 /// numerical value. A lower numerical value indicates a higher priority.
 ///
+/// The special name `*` in the priority list matches any remote name.
+///
 pub struct RemotePriorization(Vec<String>);
 
 impl RemotePriorization {
     /// Query the priority for a remote
     ///
-    /// If the remote's name is not found, the lowest possible priority is
-    /// returned.
+    /// If the remote's name is not found, `None` is returned.
     ///
-    pub fn priority_for_remote(&self, remote: &str) -> usize {
+    pub fn priority_for_remote(&self, remote: &str) -> Option<usize> {
         self.0
             .iter()
-            .position(|item| *item == remote)
+            .position(|item| *item == remote || *item == "*")
             .map(|pos| pos + 1)
-            .unwrap_or(usize::max_value())
     }
 
     /// Query the priority of a reference
@@ -69,11 +69,11 @@ impl RemotePriorization {
     /// reference. If the reference does not appear to be a remote, the highest
     /// possible priority is returned.
     ///
-    pub fn priority_for_ref(&self, reference: &Reference) -> usize {
-        reference
-            .remote()
-            .map(|name| self.priority_for_remote(name))
-            .unwrap_or(0)
+    pub fn priority_for_ref(&self, reference: &Reference) -> Option<usize> {
+        match reference.remote() {
+            Some(remote) => self.priority_for_remote(remote),
+            None => Some(0),
+        }
     }
 }
 
@@ -97,6 +97,11 @@ impl<'r, I> ReferrencesExt<'r> for I
 {
     fn select_ref(self, prios: RemotePriorization) -> Option<Reference<'r>> {
         self.into_iter()
-            .min_by_key(|reference| prios.priority_for_ref(reference.borrow()))
+            .filter_map(|reference| prios
+                .priority_for_ref(reference.borrow())
+                .map(|prio| (reference, prio))
+            )
+            .min_by_key(|item| item.1)
+            .map(|item| item.0)
     }
 }

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -89,13 +89,13 @@ impl<'a> From<&'a str> for RemotePriorization {
 pub trait ReferrencesExt<'r> {
     /// Select the reference with the highest priority
     ///
-    fn select_ref(self, prios: RemotePriorization) -> Option<Reference<'r>>;
+    fn select_ref(self, prios: &RemotePriorization) -> Option<Reference<'r>>;
 }
 
 impl<'r, I> ReferrencesExt<'r> for I
     where I: IntoIterator<Item = Reference<'r>>,
 {
-    fn select_ref(self, prios: RemotePriorization) -> Option<Reference<'r>> {
+    fn select_ref(self, prios: &RemotePriorization) -> Option<Reference<'r>> {
         self.into_iter()
             .filter_map(|reference| prios
                 .priority_for_ref(reference.borrow())

--- a/src/util.rs
+++ b/src/util.rs
@@ -207,7 +207,7 @@ impl<'r> RepositoryUtil<'r> for Repository {
         let config = self
             .config()
             .chain_err(|| EK::CannotGetRepositoryConfig)?;
-        Ok(RemotePriorization::from(config.get_str("dit.remote-prios").unwrap_or_default()))
+        Ok(RemotePriorization::from(config.get_str("dit.remote-prios").unwrap_or("*")))
     }
 }
 


### PR DESCRIPTION
On second thought, it doesn't make much sense to automatically include remotes which are not prioritized by the user in the selection of references.

This PR changes the behavior accordingly. Instead, we allow for a special entry "*", which accepts any remote.

Blocks #134.