### PR TITLE
Fix garbage collection of leaves considering remote refs

### DIFF
--- a/lib/src/gc.rs
+++ b/lib/src/gc.rs
@@ -170,8 +170,12 @@ impl<'r, I, J> CollectableRefs<'r, I, J>
 
             // remote refs
             if self.consider_remote_refs {
-                for item in issue.local_refs(IssueRefType::Leaf)? {
-                    refs_to_assess.push(item?);
+                for item in issue.remote_refs(IssueRefType::Any)? {
+                    messages.push(item?
+                        .peel(git2::ObjectType::Commit)
+                        .chain_err(|| EK::CannotGetCommit)?
+                        .id()
+                    )?;
                 }
             }
         }


### PR DESCRIPTION
If remote references are considered during garbage collection, those
references should serve as starting points for the collection. We
erroneously added local references to the list of references (once
again) to be considered for collection instead. This resulted in leaves
not being collected when they should be.

This patch resolves the bug by pushing the remote references to the
correct revwalk.