### PR TITLE
Return set of unique issues from RepositoryExt functions

### DIFF
--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -316,6 +316,14 @@ impl<'r> fmt::Display for Issue<'r> {
     }
 }
 
+impl<'r> PartialEq for Issue<'r> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl<'r> Eq for Issue<'r> {}
+
 
 
 

--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -14,6 +14,7 @@
 
 use git2::{self, Commit, Oid, Reference, References};
 use std::fmt;
+use std::hash;
 use std::result::Result as RResult;
 
 use error::*;
@@ -323,6 +324,14 @@ impl<'r> PartialEq for Issue<'r> {
 }
 
 impl<'r> Eq for Issue<'r> {}
+
+impl<'r> hash::Hash for Issue<'r> {
+    fn hash<H>(&self, state: &mut H)
+        where H: hash::Hasher
+    {
+        self.id.hash(state);
+    }
+}
 
 
 

--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -201,7 +201,7 @@ impl RepositoryExt for git2::Repository {
     fn collectable_refs<'a>(&'a self) -> Result<CollectableRefs<'a>> {
         self.issues()?
             .collect_result()
-            .map(|issues| gc::CollectableRefs::new(self, issues))
+            .map(|issues: Vec<_>| gc::CollectableRefs::new(self, issues))
     }
 
     fn issue_messages_iter<'a>(&'a self, commit: Commit<'a>) -> Result<iter::IssueMessagesIter<'a>> {

--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -65,7 +65,7 @@ pub trait RepositoryExt {
     /// prefix provided (e.g. all issues for which refs exist under
     /// `<prefix>/dit/`). Provide "refs" as the prefix to get only local issues.
     ///
-    fn issues_with_prefix(&self, prefix: &str) -> Result<iter::HeadRefsToIssuesIter>;
+    fn issues_with_prefix(&self, prefix: &str) -> Result<UniqueIssues>;
 
     /// Get all issue hashes
     ///
@@ -156,11 +156,12 @@ impl RepositoryExt for git2::Repository {
         Err(Error::from_kind(EK::NoTreeInitFound(message.id())))
     }
 
-    fn issues_with_prefix(&self, prefix: &str) -> Result<iter::HeadRefsToIssuesIter> {
+    fn issues_with_prefix(&self, prefix: &str) -> Result<UniqueIssues> {
         let glob = format!("{}/dit/**/head", prefix);
         self.references_glob(&glob)
             .chain_err(|| EK::CannotGetReferences(glob))
-            .map(|refs| iter::HeadRefsToIssuesIter::new(self, refs))
+            .map(|refs| iter::HeadRefsToIssuesIter::new(self, refs))?
+            .collect_result()
     }
 
     fn issues(&self) -> Result<UniqueIssues> {

--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -14,6 +14,7 @@
 //!
 
 use git2::{self, Commit, Oid, Tree};
+use std::collections::HashSet;
 
 use gc;
 use issue::Issue;
@@ -23,6 +24,10 @@ use utils::ResultIterExt;
 use error::*;
 use error::ErrorKind as EK;
 
+
+/// Set of unique issues
+///
+pub type UniqueIssues<'a> = HashSet<Issue<'a>>;
 
 /// Convenience alias for easier use of the CollectableRefs type
 ///

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -17,21 +17,26 @@ use std::result::Result as RResult;
 
 /// Trait for pre-accumulating results
 pub trait ResultIterExt<I, E> : Sized {
-    fn collect_result(self) -> RResult<Vec<I>, E> {
-        let mut res = Vec::new();
+    fn collect_result<T>(self) -> RResult<T, E>
+        where T: Extend<I> + Default
+    {
+        let mut res = T::default();
         self.collect_result_into(&mut res)?;
         Ok(res)
     }
 
-    fn collect_result_into(self, target: &mut Vec<I>) -> RResult<(), E>;
+    fn collect_result_into<T>(self, target: &mut T) -> RResult<(), E>
+        where T: Extend<I> + Default;
 }
 
 impl<I, E, J> ResultIterExt<I, E> for J
     where J: Iterator<Item = RResult<I, E>>
 {
-    fn collect_result_into(self, target: &mut Vec<I>) -> RResult<(), E> {
+    fn collect_result_into<T>(self, target: &mut T) -> RResult<(), E>
+        where T: Extend<I> + Default
+    {
         for item in self {
-            target.push(item?);
+            target.extend(Some(item?));
         }
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,7 +192,7 @@ fn get_issue_metadata(matches: &clap::ArgMatches) {
 fn get_issue_tree_init_hashes(_: &clap::ArgMatches) {
     let repo = util::open_dit_repo().unwrap_or_abort();
 
-    io::stdout().consume_lines(repo.issues().abort_on_err()).unwrap_or_abort();
+    io::stdout().consume_lines(repo.issues().unwrap_or_abort()).unwrap_or_abort();
 }
 
 
@@ -213,7 +213,7 @@ fn fetch_impl(matches: &clap::ArgMatches) {
         // fetch a specific list of issues
         let iter = issues.map(|issue| repo.value_to_issue(issue)).abort_on_err();
         if matches.is_present("known") {
-            iter.chain(repo.issues().abort_on_err())
+            iter.chain(repo.issues().unwrap_or_abort())
                 .filter_map(|issue| remote.issue_refspec(issue))
                 .collect()
         } else {
@@ -291,7 +291,8 @@ fn list_impl(matches: &clap::ArgMatches) {
     // get initial commits
     let mut issues : Vec<Issue> = repo
         .issues()
-        .abort_on_err()
+        .unwrap_or_abort()
+        .into_iter()
         .filter(|issue| filter.filter(issue))
         .collect();
 
@@ -363,7 +364,7 @@ fn mirror_impl(matches: &clap::ArgMatches) {
         .unwrap_or_else(|| repo.remote_priorization().unwrap_or_abort());
     let issues = repo
         .cli_issues(matches)
-        .unwrap_or_else(|| repo.issues().abort_on_err().collect());
+        .unwrap_or_else(|| repo.issues().unwrap_or_abort().into_iter().collect());
 
     for issue in issues {
         if clone_head || update_head {
@@ -495,7 +496,7 @@ fn push_impl(matches: &clap::ArgMatches) {
     // accumulate the refspecs to push
     let refspecs : Vec<String> = repo
         .cli_issues(matches)
-        .unwrap_or_else(|| repo.issues().abort_on_err().collect())
+        .unwrap_or_else(|| repo.issues().unwrap_or_abort().into_iter().collect())
         .into_iter()
         .map(|issue| issue.local_refs(IssueRefType::Any))
         .abort_on_err()

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,7 +364,7 @@ fn mirror_impl(matches: &clap::ArgMatches) {
         .unwrap_or_else(|| repo.remote_priorization().unwrap_or_abort());
     let issues = repo
         .cli_issues(matches)
-        .unwrap_or_else(|| repo.issues().unwrap_or_abort().into_iter().collect());
+        .unwrap_or_else(|| repo.issues().unwrap_or_abort());
 
     for issue in issues {
         if clone_head || update_head {
@@ -496,7 +496,7 @@ fn push_impl(matches: &clap::ArgMatches) {
     // accumulate the refspecs to push
     let refspecs : Vec<String> = repo
         .cli_issues(matches)
-        .unwrap_or_else(|| repo.issues().unwrap_or_abort().into_iter().collect())
+        .unwrap_or_else(|| repo.issues().unwrap_or_abort())
         .into_iter()
         .map(|issue| issue.local_refs(IssueRefType::Any))
         .abort_on_err()

--- a/src/util.rs
+++ b/src/util.rs
@@ -16,6 +16,7 @@ use std::str::FromStr;
 
 use libgitdit::message::LineIteratorExt;
 use libgitdit::message::trailer::Trailer;
+use libgitdit::repository::UniqueIssues;
 use libgitdit::{Issue, RepositoryExt};
 
 use abort::{Abortable, IteratorExt};
@@ -66,7 +67,7 @@ pub trait RepositoryUtil<'r> {
     ///
     /// This function parses the issues specified via the `"issue"` field.
     ///
-    fn cli_issues(&'r self, matches: &ArgMatches) -> Option<Vec<Issue<'r>>>;
+    fn cli_issues(&'r self, matches: &ArgMatches) -> Option<UniqueIssues<'r>>;
 
     /// Retrieve the references from the command line
     ///
@@ -136,7 +137,7 @@ impl<'r> RepositoryUtil<'r> for Repository {
                .and_then(|value| self.value_to_issue(value))
     }
 
-    fn cli_issues(&'r self, matches: &ArgMatches) -> Option<Vec<Issue<'r>>> {
+    fn cli_issues(&'r self, matches: &ArgMatches) -> Option<UniqueIssues<'r>> {
         matches
             .values_of("issue")
             .map(|values| values


### PR DESCRIPTION
`RepositoryExt::issues()` and `RepositoryExt::issues_with_prefix()` both
return an iterator over issues. In both cases, the issues are not
guaranteed to be unique and with the current implementation, an issue
may well be reported twice.

We implicitly assumed that issues would be reported only once. This lead
to `git-dit-list` reporting an issue twice if both a remote and a local
head reference exist for that issue. `git-dit-gc` would try to remove a
reference twice and hence display an error.

We could fix the behavior in places where we made the assumption.
However, when querying a list of issues it is sensible to assume that
the list would contain unique issues. This patch-set therefore aims at
changing the aforementioned query functions of `RepositoryExt`, making
each of them return a set of issues.