### PR TITLE
Remove ambiguous short option "h" from "gc" subcommand

### DIFF
--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -196,7 +196,6 @@ subcommands:
                 multiple: false
                 takes_value: false
             - collect-heads:
-                short: h
                 long: collect-heads
                 help: Also collect local heads
                 multiple: false


### PR DESCRIPTION
The option conflicts with the global "help" option.
Even worse, users may accidentally trigger removal of references when
trying to read the help-message.