### PR TITLE
Redefine internals of Issue

### DIFF
--- a/lib/src/issue.rs
+++ b/lib/src/issue.rs
@@ -130,7 +130,7 @@ impl<'r> Issue<'r> {
     /// Get the issue's initial message
     ///
     pub fn initial_message(&self) -> Result<git2::Commit<'r>> {
-        self.repo.find_commit(self.id).chain_err(|| EK::CannotGetCommit)
+        self.repo.find_commit(self.id()).chain_err(|| EK::CannotGetCommit)
     }
 
     /// Get possible heads of the issue
@@ -142,7 +142,7 @@ impl<'r> Issue<'r> {
         let glob = format!("**/dit/{}/head", self.ref_part());
         self.repo
             .references_glob(&glob)
-            .chain_err(|| EK::CannotFindIssueHead(self.id))
+            .chain_err(|| EK::CannotFindIssueHead(self.id()))
     }
 
     /// Get the local issue head for the issue
@@ -154,7 +154,7 @@ impl<'r> Issue<'r> {
         let refname = format!("refs/dit/{}/head", self.ref_part());
         self.repo
             .find_reference(&refname)
-            .chain_err(|| EK::CannotFindIssueHead(self.id))
+            .chain_err(|| EK::CannotFindIssueHead(self.id()))
     }
 
     /// Get local references for the issue
@@ -307,19 +307,19 @@ impl<'r> Issue<'r> {
     /// part after the  `dit/`.
     ///
     pub fn ref_part(&self) -> String {
-        self.id.to_string()
+        self.id().to_string()
     }
 }
 
 impl<'r> fmt::Display for Issue<'r> {
     fn fmt(&self, f: &mut fmt::Formatter) -> RResult<(), fmt::Error> {
-        write!(f, "{}", self.id)
+        write!(f, "{}", self.id())
     }
 }
 
 impl<'r> PartialEq for Issue<'r> {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
+        self.id() == other.id()
     }
 }
 
@@ -329,7 +329,7 @@ impl<'r> hash::Hash for Issue<'r> {
     fn hash<H>(&self, state: &mut H)
         where H: hash::Hasher
     {
-        self.id.hash(state);
+        self.id().hash(state);
     }
 }
 

--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -113,7 +113,7 @@ pub trait RepositoryExt {
 
 impl RepositoryExt for git2::Repository {
     fn find_issue(&self, id: Oid) -> Result<Issue> {
-        let retval = Issue::new(self, id);
+        let retval = Issue::new(self, id)?;
 
         // make sure the id refers to an issue by checking whether an associated
         // head reference exists
@@ -140,7 +140,7 @@ impl RepositoryExt for git2::Repository {
                Oid::from_str(hash)
                    .chain_err(|| EK::OidFormatError(hash.to_string()))
             })
-            .map(|id| Issue::new(self, id))
+            .and_then(|id| Issue::new(self, id))
     }
 
     fn issue_with_message<'a>(&'a self, message: &Commit<'a>) -> Result<Issue> {
@@ -187,7 +187,7 @@ impl RepositoryExt for git2::Repository {
 
         self.commit(None, author, committer, message.as_ref(), tree, &parent_vec)
             .chain_err(|| EK::CannotCreateMessage)
-            .map(|id| Issue::new(self, id))
+            .and_then(|id| Issue::new(self, id))
             .and_then(|issue| {
                 issue.update_head(issue.id(), true)?;
                 Ok(issue)


### PR DESCRIPTION
Some existing and future functions of `Issue` operate on the initial message of the issue. If we store only the `Issue`s id, we have to retrieve the commit on multiple occasions, e.g. we have a potential for a lot of overhead.

Ideally, we would store the initial message as a `git2::Commit`. However, this is not practical due to some drawbacks of the interface. Storing an `Object` on the other hand provides at least some caching as well as other benefits.