### PR TITLE
Add issue filtering as a library feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ chrono = "0.3"
 error-chain = "0.10"
 git2 = "0.6"
 is-match = "0.1"
+lazy_static = "0.2"
 log = "0.3"
+regex = "0.2"
 
 [dependencies.clap]
 version = "2.23"

--- a/lib/src/trailer/accumulation.rs
+++ b/lib/src/trailer/accumulation.rs
@@ -103,6 +103,35 @@ pub trait Accumulator {
     }
 }
 
+
+/// Trait for accumulators accumulating multiple values
+///
+/// # Note
+///
+/// This trait really is a convenience trait for consolidating mapping
+/// containers. It only exists because the standart library doesn't provide
+/// any matching traits (the `Index` trait is not an option).
+///
+pub trait MultiAccumulator {
+    /// Get the ValueAccumulator associated with a given string
+    ///
+    fn get(&self, key: &str) -> Option<&ValueAccumulator>;
+
+    /// Get the ValueAccumulator associated with a given string, mutable
+    ///
+    fn get_mut(&mut self, key: &str) -> Option<&mut ValueAccumulator>;
+}
+
+impl<M> Accumulator for M
+    where M: MultiAccumulator
+{
+    fn process(&mut self, trailer: Trailer) {
+        let (key, value) = trailer.into();
+        self.get_mut(key.as_ref())
+            .map(|ref mut acc| acc.process(value));
+    }
+}
+
 // TODO: consolidate the implementation for map types, should there ever be an
 //       appropriate map trait in `std`.
 impl<S> Accumulator for collections::HashMap<String, ValueAccumulator, S>

--- a/lib/src/trailer/accumulation.rs
+++ b/lib/src/trailer/accumulation.rs
@@ -36,6 +36,7 @@ pub enum AccumulationPolicy {
 /// This type encapsulates the task of accumulating trailers in an appropriate
 /// data structure.
 ///
+#[derive(Clone)]
 pub enum ValueAccumulator {
     Latest(Option<TrailerValue>),
     List(Vec<TrailerValue>),

--- a/lib/src/trailer/accumulation.rs
+++ b/lib/src/trailer/accumulation.rs
@@ -132,23 +132,25 @@ impl<M> Accumulator for M
     }
 }
 
-// TODO: consolidate the implementation for map types, should there ever be an
-//       appropriate map trait in `std`.
-impl<S> Accumulator for collections::HashMap<String, ValueAccumulator, S>
+impl<S> MultiAccumulator for collections::HashMap<String, ValueAccumulator, S>
     where S: BuildHasher
 {
-    fn process(&mut self, trailer: Trailer) {
-        let (key, value) = trailer.into();
-        self.get_mut(key.as_ref())
-            .map(|ref mut acc| acc.process(value));
+    fn get(&self, key: &str) -> Option<&ValueAccumulator> {
+        collections::HashMap::get(self, key)
+    }
+
+    fn get_mut(&mut self, key: &str) -> Option<&mut ValueAccumulator> {
+        collections::HashMap::get_mut(self, key)
     }
 }
 
-impl Accumulator for collections::BTreeMap<String, ValueAccumulator> {
-    fn process(&mut self, trailer: Trailer) {
-        let (key, value) = trailer.into();
-        self.get_mut(key.as_ref())
-            .map(|ref mut acc| acc.process(value));
+impl MultiAccumulator for collections::BTreeMap<String, ValueAccumulator> {
+    fn get(&self, key: &str) -> Option<&ValueAccumulator> {
+        collections::BTreeMap::get(self, key)
+    }
+
+    fn get_mut(&mut self, key: &str) -> Option<&mut ValueAccumulator> {
+        collections::BTreeMap::get_mut(self, key)
     }
 }
 

--- a/lib/src/trailer/filter.rs
+++ b/lib/src/trailer/filter.rs
@@ -1,0 +1,47 @@
+// git-dit - the distributed issue tracker for git
+// Copyright (C) 2016, 2017 Matthias Beyer <mail@beyermatthias.de>
+// Copyright (C) 2016, 2017 Julian Ganz <neither@nut.email>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+//! Trailer based filtering
+//!
+
+use std::borrow::Borrow;
+
+use trailer::TrailerValue;
+
+
+/// Type for matching TrailerValues
+///
+pub enum ValueMatcher {
+    Any,
+    Equals(TrailerValue),
+    Contains(String),
+}
+
+impl ValueMatcher {
+    /// Check whether the value supplied matches the matcher
+    ///
+    pub fn matches(&self, value: &TrailerValue) -> bool
+    {
+        match self {
+            &ValueMatcher::Any             => true,
+            &ValueMatcher::Equals(ref v)   => value == v,
+            &ValueMatcher::Contains(ref s) => value.to_string().contains(s),
+        }
+    }
+
+    /// Check whether any of the value supplied matches the matcher
+    ///
+    pub fn matches_any<I, V>(&self, values: I) -> bool
+        where I: IntoIterator<Item = V>,
+              V: Borrow<TrailerValue>
+    {
+        values.into_iter().any(|v| self.matches(v.borrow()))
+    }
+}
+

--- a/lib/src/trailer/filter.rs
+++ b/lib/src/trailer/filter.rs
@@ -13,6 +13,8 @@
 use std::borrow::Borrow;
 
 use trailer::TrailerValue;
+use trailer::accumulation::ValueAccumulator;
+use trailer::spec::TrailerSpec;
 
 
 /// Type for matching TrailerValues
@@ -42,6 +44,32 @@ impl ValueMatcher {
               V: Borrow<TrailerValue>
     {
         values.into_iter().any(|v| self.matches(v.borrow()))
+    }
+}
+
+
+/// Trailer based filter
+///
+pub struct TrailerFilter<'a> {
+    trailer: TrailerSpec<'a>,
+    matcher: ValueMatcher,
+}
+
+impl<'a> TrailerFilter<'a> {
+    pub fn new(trailer: TrailerSpec<'a>, matcher: ValueMatcher) -> Self {
+        Self { trailer: trailer, matcher: matcher }
+    }
+
+    pub fn matches<'b>(&self, accumulator: &::std::collections::HashMap<String, ValueAccumulator>) -> bool {
+        let values = accumulator
+            .get(self.trailer.key)
+            .cloned()
+            .unwrap_or_default();
+        self.matcher.matches_any(values)
+    }
+
+    pub fn spec(&self) -> &TrailerSpec<'a> {
+        &self.trailer
     }
 }
 

--- a/lib/src/trailer/mod.rs
+++ b/lib/src/trailer/mod.rs
@@ -99,6 +99,12 @@ impl TrailerValue {
     }
 }
 
+impl Default for TrailerValue {
+    fn default() -> Self {
+        TrailerValue::String(String::new())
+    }
+}
+
 impl fmt::Display for TrailerValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> RResult<(), fmt::Error> {
         match *self {

--- a/lib/src/trailer/mod.rs
+++ b/lib/src/trailer/mod.rs
@@ -15,6 +15,7 @@
 //!
 
 pub mod accumulation;
+pub mod filter;
 pub mod iter;
 pub mod spec;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,11 @@ error_chain! {
             display("Malformed filter spec: {}", spec)
         }
 
+        UnknownMetadataKey(key: String) {
+            description("Unknown metadata key")
+            display("Unknown metadata key: {}", key)
+        }
+
         WrappedIOError {
             description("IO Error")
             display("IO Error")

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -32,6 +32,12 @@ pub struct FilterSpec {
     negated: bool,
 }
 
+impl FilterSpec {
+    fn into_trailer<'a>(self, spec: spec::TrailerSpec<'a>) -> (TrailerFilter<'a>, bool) {
+        (TrailerFilter::new(spec, self.matcher), self.negated)
+    }
+}
+
 impl FromStr for FilterSpec {
     type Err = Error;
 
@@ -99,8 +105,8 @@ impl<'a> MetadataFilter<'a> {
 
         for s in spec.into_iter() {
             match s.key.as_ref() {
-                "status"    => trailers.push((TrailerFilter::new(spec::ISSUE_STATUS_SPEC.clone(), s.matcher), s.negated)),
-                "type"      => trailers.push((TrailerFilter::new(spec::ISSUE_TYPE_SPEC.clone(), s.matcher), s.negated)),
+                "status"    => trailers.push(s.into_trailer(spec::ISSUE_STATUS_SPEC.clone())),
+                "type"      => trailers.push(s.into_trailer(spec::ISSUE_TYPE_SPEC.clone())),
                 _           => return Err(Error::from_kind(EK::UnknownMetadataKey(s.key.to_string()))),
             }
         }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -83,7 +83,7 @@ impl FromStr for FilterSpec {
     fn from_str(s: &str) -> Result<Self> {
         lazy_static! {
             // regex for parsing a trailer spec
-            static ref RE: Regex = Regex::new(r"^(!)?([[:alnum:]-]+)((:|~)(.*))?$").unwrap();
+            static ref RE: Regex = Regex::new(r"^(!)?([[:alnum:]-]+)((=|~)(.*))?$").unwrap();
         }
 
         let parts = RE
@@ -110,7 +110,7 @@ impl FromStr for FilterSpec {
                 .ok_or_else(|| Error::from_kind(EK::MalformedFilterSpec(s.to_owned())))?;
 
             match op {
-                ":" => ValueMatcher::Equals(TrailerValue::from_slice(value)),
+                "=" => ValueMatcher::Equals(TrailerValue::from_slice(value)),
                 "~" => ValueMatcher::Contains(value.to_string()),
                 _   => return Err(Error::from_kind(EK::MalformedFilterSpec(s.to_owned()))),
             }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -71,6 +71,10 @@ impl FilterSpec {
     fn into_trailer<'a>(self, spec: spec::TrailerSpec<'a>) -> (TrailerFilter<'a>, bool) {
         (TrailerFilter::new(spec, self.matcher), self.negated)
     }
+
+    fn into_nontrailer<'a>(self, spec: NonTrailer) -> (NonTrailer, ValueMatcher, bool) {
+        (spec, self.matcher, self.negated)
+    }
 }
 
 impl FromStr for FilterSpec {

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -19,6 +19,41 @@ use gitext::{RemotePriorization, ReferrencesExt};
 use system::{Abortable, IteratorExt};
 
 
+/// Representation of non-trailer metadata
+///
+enum NonTrailer {
+    ReporterName,
+    ReporterEMail,
+}
+
+impl NonTrailer {
+    /// Retrieve the value for a given issue
+    ///
+    pub fn for_issue(&self, issue: &Issue) -> Result<TrailerValue> {
+        match self {
+            &NonTrailer::ReporterName => {
+                let initial = issue.initial_message()?;
+                let value = initial
+                    .author()
+                    .name()
+                    .map(TrailerValue::from_slice)
+                    .unwrap_or_default();
+                Ok(value)
+            },
+            &NonTrailer::ReporterEMail => {
+                let initial = issue.initial_message()?;
+                let value = initial
+                    .author()
+                    .email()
+                    .map(TrailerValue::from_slice)
+                    .unwrap_or_default();
+                Ok(value)
+            },
+        }
+    }
+}
+
+
 /// Filter specification
 ///
 /// This type represents a filter rule for a single piece of metadata.

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -36,7 +36,7 @@ impl FromStr for FilterSpec {
     fn from_str(s: &str) -> Result<Self> {
         lazy_static! {
             // regex for parsing a trailer spec
-            static ref RE: Regex = Regex::new(r"^([[:alnum:]-]+):(.*)$").unwrap();
+            static ref RE: Regex = Regex::new(r"^([[:alnum:]-]+)((:|~)(.*))?$").unwrap();
         }
 
         let parts = RE
@@ -49,14 +49,29 @@ impl FromStr for FilterSpec {
             .map(Match::as_str)
             .ok_or_else(|| Error::from_kind(EK::MalformedFilterSpec(s.to_owned())))?;
 
-        let value = parts
-            .get(2)
-            .as_ref()
-            .map(Match::as_str)
-            .map(TrailerValue::from_slice)
-            .ok_or_else(|| Error::from_kind(EK::MalformedFilterSpec(s.to_owned())))?;
+        let matcher = if parts.get(2).is_some() {
+            let op = parts
+                .get(3)
+                .as_ref()
+                .map(Match::as_str)
+                .ok_or_else(|| Error::from_kind(EK::MalformedFilterSpec(s.to_owned())))?;
 
-        Ok(FilterSpec {key: key.to_string(), matcher: ValueMatcher::Equals(value)})
+            let value = parts
+                .get(4)
+                .as_ref()
+                .map(Match::as_str)
+                .ok_or_else(|| Error::from_kind(EK::MalformedFilterSpec(s.to_owned())))?;
+
+            match op {
+                ":" => ValueMatcher::Equals(TrailerValue::from_slice(value)),
+                "~" => ValueMatcher::Contains(value.to_string()),
+                _   => return Err(Error::from_kind(EK::MalformedFilterSpec(s.to_owned()))),
+            }
+        } else {
+            ValueMatcher::Any
+        };
+
+        Ok(FilterSpec {key: key.to_string(), matcher: matcher})
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,7 +263,7 @@ fn list_impl(matches: &clap::ArgMatches) {
     let filter = match matches.values_of("filter") {
         Some(values) => {
             let specs = values.map(str::parse).abort_on_err();
-            MetadataFilter::new(&remote_prios, specs)
+            MetadataFilter::new(&remote_prios, specs).unwrap_or_abort()
         },
         None         => MetadataFilter::empty(&remote_prios),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,12 @@
 #[macro_use] extern crate clap;
 #[macro_use] extern crate error_chain;
 #[macro_use] extern crate is_match;
+#[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
 extern crate chrono;
 extern crate git2;
 extern crate libgitdit;
+extern crate regex;
 
 mod display;
 mod error;


### PR DESCRIPTION
Filtering issues based on metadata should be a relatively common task in applications associated with git-dit, including web-viewers and of course the `git-dit` binary. It therefore makes sense to provide some functionality associated with filtering in the library.