### PR TITLE
Flexible message formatting

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -54,6 +54,7 @@ mod utils;
 mod test_utils;
 
 // A selection of types are reexported for more convenient access.
+pub use error::Error;
 pub use issue::Issue;
 pub use message::Message;
 pub use remote::RemoteExt;

--- a/src/display/formatter.rs
+++ b/src/display/formatter.rs
@@ -195,3 +195,30 @@ impl<I, J, T, K, B> Iterator for FormattedLines<I, J, T, K, B>
     }
 }
 
+
+/// Convenience trait for creating a FormattedLines
+///
+/// Users of formatting facilities will most probably use this trait for
+/// performing the formatting.
+///
+pub trait LineFormatter<I, J, T, K, B>
+    where I: Iterator<Item = J>, // Underlying token iterator
+          J: Borrow<FormattingToken<T, K>>, // Tokens returned by the iterator
+          T: TokenExpander<Item = K>, // The specific token expander
+          B: Borrow<K> // Reference of item to format
+{
+    fn formatted_lines(self, item: B) -> FormattedLines<I, J, T, K, B>;
+}
+
+impl<A, I, J, T, K, B> LineFormatter<I, J, T, K, B> for A
+    where A: IntoIterator<Item = J, IntoIter = I>,
+          I: Iterator<Item = J>,
+          J: Borrow<FormattingToken<T, K>>,
+          T: TokenExpander<Item = K>,
+          B: Borrow<K>
+{
+    fn formatted_lines(self, item: B) -> FormattedLines<I, J, T, K, B> {
+        FormattedLines::new(self, item)
+    }
+}
+

--- a/src/display/formatter.rs
+++ b/src/display/formatter.rs
@@ -92,3 +92,106 @@ impl<T, B> Borrow<T> for BorrowHelper<T, B>
     }
 }
 
+
+/// Adapter iterator for transforming formatting tokens to lines of text
+///
+/// This adapter wraps an iterator over formatting tokens, bundled with an item
+/// to format.
+/// All `Expandable` tokens returned by the wrapped iterator will be expanded
+/// recursively.
+/// The iterator will construct lines from the resulting "simple" tokens, which
+/// will be returned as items.
+///
+pub struct FormattedLines<I, J, T, K, B>
+    where I: Iterator<Item = J>, // Underlying token iterator
+          J: Borrow<FormattingToken<T, K>>, // Tokens returned by the iterator
+          T: TokenExpander<Item = K>, // The specific token expander
+          // K: Item to format
+          B: Borrow<K> // Reference of item to format
+{
+    inner: I,
+    item: B,
+    tokenstack: Vec<BorrowHelper<FormattingToken<T, K>, J>>,
+}
+
+impl<I, J, T, K, B> FormattedLines<I, J, T, K, B>
+    where I: Iterator<Item = J>,
+          J: Borrow<FormattingToken<T, K>>,
+          T: TokenExpander<Item = K>,
+          B: Borrow<K>
+{
+    pub fn new<A>(inner: A, item: B) -> Self
+        where A: IntoIterator<Item = J, IntoIter = I>
+    {
+        FormattedLines {
+            inner: inner.into_iter(),
+            tokenstack: Vec::new(),
+            item: item
+        }
+    }
+}
+
+impl<I, J, T, K, B> Iterator for FormattedLines<I, J, T, K, B>
+    where I: Iterator<Item = J>,
+          J: Borrow<FormattingToken<T, K>>,
+          T: TokenExpander<Item = K>,
+          B: Borrow<K>
+{
+    type Item = Result<String, T::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Implementers' note: in case you did not guess by now, this adapter
+        // is implemented as a stack machine. As described in the user
+        // implementation, "simple" tokens are used for composing lines.
+        // `Expandable` tokens are expanded to new tokens via the build-in
+        // expansion mechanism.
+        // Since those tokens may contain line-ends, we have have to buffer
+        // them. Since they may contain other `Expandable` tokens, we cannot
+        // simply store the returned list but put them on the `tokenstack`.
+        // From that stack, we pop an item and process it, which may result in
+        // more expanded items on the stack.
+        let mut line: Option<String> = None;
+        loop {
+            // Retrieve a token. Check the stack first before consulting the
+            // inner iterator.
+            let token = match self
+                .tokenstack
+                .pop()
+                .or_else(|| self.inner.next().map(BorrowHelper::Borrowed))
+            {
+                Some(val)   => val,
+                None        => break,
+            };
+
+            match token.borrow() {
+                &FormattingToken::Expandable(ref expander, _) => match expander
+                    .expand_token(self.item.borrow())
+                {
+                    Ok(mut tokens) => {
+                        // Put the tokens on the stack, in reverse order since we are popping
+                        // items rather than iterating over them.
+                        tokens.reverse();
+                        self.tokenstack
+                            .extend(tokens.into_iter().map(BorrowHelper::Value));
+                    },
+                    Err(err) => return Some(Err(err)),
+                },
+                &FormattingToken::Text(ref text) => {
+                    // Expand the "simple" token.
+                    line = Some(line.take().unwrap_or_default() + text);
+                },
+                &FormattingToken::LineEnd => {
+                    // Make sure we return a line one each line end, even if
+                    // it's empty.
+                    if line.is_none() {
+                        line = Some(String::new())
+                    }
+                    // Return the line
+                    break
+                },
+            }
+        }
+        line.map(|l| Ok(l))
+    }
+}
+

--- a/src/display/formatter.rs
+++ b/src/display/formatter.rs
@@ -1,0 +1,71 @@
+//   git-dit - the distributed issue tracker for git
+//   Copyright (C) 2016, 2017 Matthias Beyer <mail@beyermatthias.de>
+//   Copyright (C) 2016, 2017 Julian Ganz <neither@nut.email>
+//
+//   This program is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License version 2 as
+//   published by the Free Software Foundation.
+//
+
+//! Generic formatting utilities
+//!
+
+use std::borrow::Borrow;
+use std::marker::PhantomData;
+
+/// Formatting tokens
+///
+/// This type represents generic formatting tokens which may be used for
+/// formatting items `I` of some sort into a sequence of lines.
+/// Formatting is done via an iterator by expanding `Expandable` tokens to
+/// `Text` and `LineEnd` tokens. The latter two will be coposed to lines.
+///
+pub enum FormattingToken<T, I>
+    where T: TokenExpander<Item = I> + Sized
+{
+    Expandable(T, PhantomData<I>),
+    Text(String),
+    LineEnd,
+}
+
+// NOTE: we could also implement some formatting trait for `FormattingToken`,
+//       e.g. `Display` or `ToString`, but the compiler won't let us because of
+//       the implementation for `From<T>`.
+impl<T, I> From<String> for FormattingToken<T, I>
+    where T: TokenExpander<Item = I> + Sized
+{
+    fn from(text: String) -> Self {
+        FormattingToken::Text(text)
+    }
+}
+
+impl<'a, T, I> From<&'a str> for FormattingToken<T, I>
+    where T: TokenExpander<Item = I> + Sized
+{
+    fn from(text: &str) -> Self {
+        FormattingToken::Text(text.to_string())
+    }
+}
+
+impl<T, I> From<T> for FormattingToken<T, I>
+    where T: TokenExpander<Item = I> + Sized
+{
+    fn from(expander: T) -> Self {
+        FormattingToken::Expandable(expander, PhantomData)
+    }
+}
+
+
+/// Token expander
+///
+/// This type is used for expanding tokens.
+/// Implementors of concrete formatting facilities will implement this trait for
+/// the type of items to be formatted.
+///
+pub trait TokenExpander: Sized {
+    type Item;
+    type Error;
+
+    fn expand_token(&self, item: &Self::Item) -> Result<Vec<FormattingToken<Self, Self::Item>>, Self::Error>;
+}
+

--- a/src/display/formatter.rs
+++ b/src/display/formatter.rs
@@ -13,6 +13,20 @@
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 
+
+/// Convenience macro for creating a token vector from token-like items
+///
+/// The items passed via the list are transformed to tokens by invoking `into()`
+/// on them. As a result, `String`s, `str`s and `TokenExpander`s may be passed
+/// as items.
+///
+macro_rules! tokenvec {
+    ( $( $tok:expr ),* ) => {
+        vec![$($tok.into(),)*]
+    };
+}
+
+
 /// Formatting tokens
 ///
 /// This type represents generic formatting tokens which may be used for

--- a/src/display/formatter.rs
+++ b/src/display/formatter.rs
@@ -69,3 +69,26 @@ pub trait TokenExpander: Sized {
     fn expand_token(&self, item: &Self::Item) -> Result<Vec<FormattingToken<Self, Self::Item>>, Self::Error>;
 }
 
+
+/// Helper type for storing eihter a type or a Borrow implementation
+///
+enum BorrowHelper<T, B>
+    where T: Sized,
+          B: Borrow<T>
+{
+    Value(T),
+    Borrowed(B),
+}
+
+impl<T, B> Borrow<T> for BorrowHelper<T, B>
+    where T: Sized,
+          B: Borrow<T>
+{
+    fn borrow(&self) -> &T {
+        match self {
+            &BorrowHelper::Value(ref val) => &val,
+            &BorrowHelper::Borrowed(ref val) => val.borrow(),
+        }
+    }
+}
+

--- a/src/display/message.rs
+++ b/src/display/message.rs
@@ -1,0 +1,99 @@
+//   git-dit - the distributed issue tracker for git
+//   Copyright (C) 2016, 2017 Matthias Beyer <mail@beyermatthias.de>
+//   Copyright (C) 2016, 2017 Julian Ganz <neither@nut.email>
+//
+//   This program is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License version 2 as
+//   published by the Free Software Foundation.
+//
+
+//! Message formatting facility
+//!
+
+use chrono::format::strftime::StrftimeItems;
+use git2::Commit;
+use libgitdit::Message;
+use libgitdit::message::block::Block;
+use libgitdit::trailer::spec::TrailerSpec;
+
+use error::*;
+use super::formatter::{TokenExpander, FormattingToken, LineTokens};
+
+/// Tokens for formatting messages
+///
+pub enum MessageFmtToken<'a> {
+    Id(usize),
+    Subject,
+    Author,
+    AuthorName,
+    AuthorEMail,
+    Date(StrftimeItems<'a>),
+    Body,
+    BodyText,
+    Trailers,
+    Trailer(TrailerSpec<'a>),
+}
+
+impl<'a,> TokenExpander for MessageFmtToken<'a> {
+    type Item = Commit<'a>;
+    type Error = Error;
+
+    fn expand_token(&self, message: &Self::Item) -> Result<Vec<FormattingToken<Self, Self::Item>>> {
+        Ok(match self {
+            &MessageFmtToken::Id(ref len) => tokenvec![format!("{0:.1$}", message.id(), len)],
+            &MessageFmtToken::Subject => tokenvec![message
+                .as_object()
+                .clone()
+                .into_commit()
+                .ok()
+                .and_then(|mut m| m.summary().map(String::from))
+                .unwrap_or_default()],
+            &MessageFmtToken::Author => tokenvec![message
+                .author()
+                .to_string()],
+            &MessageFmtToken::AuthorName => tokenvec![message
+                .author()
+                .name()
+                .unwrap_or_default()],
+            &MessageFmtToken::AuthorEMail => tokenvec![message
+                .author()
+                .email()
+                .unwrap_or_default()],
+            &MessageFmtToken::Date(ref format) => {
+                use chrono::{FixedOffset, TimeZone};
+
+                let gtime = message.time();
+                tokenvec![FixedOffset::east(gtime.offset_minutes()*60)
+                    .timestamp(gtime.seconds(), 0)
+                    .format_with_items(format.clone())
+                    .to_string()]
+            }
+            &MessageFmtToken::Body => message
+                .body_lines()
+                .line_tokens()
+                .collect(),
+            &MessageFmtToken::BodyText => message
+                .body_blocks()
+                .flat_map(|block| match block {
+                    Block::Text(mut lines) => {
+                        // add a blank line after each paragraph
+                        lines.push(String::new());
+                        lines
+                    },
+                    _ => vec![],
+                })
+                .line_tokens()
+                .collect(),
+            &MessageFmtToken::Trailers => message
+                .trailers()
+                .line_tokens()
+                .collect(),
+            &MessageFmtToken::Trailer(ref spec) => message
+                .trailers()
+                .filter(|trailer| trailer.key.as_ref() == spec.key)
+                .line_tokens()
+                .collect(),
+        })
+    }
+}
+

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -7,7 +7,8 @@
 //   published by the Free Software Foundation.
 //
 
-mod formatter;
+#[macro_use] mod formatter;
+
 mod message;
 mod msgtree;
 

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -7,7 +7,9 @@
 //   published by the Free Software Foundation.
 //
 
+mod formatter;
 mod msgtree;
 
+pub use self::formatter::*;
 pub use self::msgtree::*;
 

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -8,8 +8,10 @@
 //
 
 mod formatter;
+mod message;
 mod msgtree;
 
 pub use self::formatter::*;
+pub use self::message::*;
 pub use self::msgtree::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,9 +254,10 @@ fn gc_impl(matches: &clap::ArgMatches) {
 /// list subcommand implementation
 ///
 fn list_impl(matches: &clap::ArgMatches) {
-    use chrono::{FixedOffset, TimeZone};
+    use chrono::format::strftime::StrftimeItems;
     use libgitdit::Issue;
 
+    use display::{FormattingToken as FT, MessageFmtToken as MFT, LineFormatter};
     use filters::MetadataFilter;
 
     let repo = util::open_dit_repo();
@@ -269,6 +270,22 @@ fn list_impl(matches: &clap::ArgMatches) {
             MetadataFilter::new(&remote_prios, specs).unwrap_or_abort()
         },
         None         => MetadataFilter::empty(&remote_prios),
+    };
+
+    let id_len = repo.abbreviation_length(matches);
+
+    let formatter = if matches.is_present("long") {
+        tokenvec![
+            MFT::Id(id_len), FT::LineEnd,
+            "Author: ", MFT::Author, FT::LineEnd,
+            "Date: ", MFT::Date(StrftimeItems::new("%+")), FT::LineEnd,
+            FT::LineEnd,
+            MFT::Subject, FT::LineEnd,
+            FT::LineEnd,
+            MFT::BodyText,
+            FT::LineEnd]
+    } else {
+        tokenvec![MFT::Id(id_len), " (", MFT::Date(StrftimeItems::new("%c")), ") ", MFT::Subject]
     };
 
     // get initial commits
@@ -292,33 +309,17 @@ fn list_impl(matches: &clap::ArgMatches) {
         issues.truncate(str::parse(number).unwrap_or_abort());
     }
 
-    let id_len = repo.abbreviation_length(matches);
-
     // spawn a pager
     let mut pager = system::programs::pager(repo.config().unwrap_or_abort())
         .unwrap_or_abort();
 
-    {
-        let mut stream = pager.stdin.as_mut().unwrap();
-        let long = matches.is_present("long");
-        for issue in issues {
-            let id = issue.id();
-            let mut commit = issue.initial_message().unwrap_or_abort();
-            let time = {
-                let gtime = commit.time();
-                FixedOffset::east(gtime.offset_minutes()*60).timestamp(gtime.seconds(), 0)
-            };
-            if long {
-                write!(stream, "Issue:  {}\nAuthor: {}\nDate:   {}\n\n", id, commit.author(), time.to_rfc3339())
-                    .unwrap_or_abort();
-                stream.consume_lines(commit.message_lines()).unwrap_or_abort();
-                write!(stream, "\n\n").unwrap_or_abort();
-            } else {
-                writeln!(stream, "{0:.1$} ({2}) {3}", id, id_len, time.format("%c"), commit.summary().unwrap_or(""))
-                    .unwrap_or_abort();
-            }
-        }
-    }
+    let lines = issues
+        .into_iter()
+        .map(|issue| issue.initial_message())
+        .abort_on_err()
+        .flat_map(|initial| formatter.iter().formatted_lines(initial))
+        .abort_on_err();
+    pager.stdin.as_mut().unwrap().consume_lines(lines).unwrap_or_abort();
 
     // don't trash the shell by exitting with a child still printing to it
     let result = pager.wait().unwrap_or_abort();

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,8 @@ extern crate git2;
 extern crate libgitdit;
 extern crate regex;
 
-mod display;
+#[macro_use] mod display;
+
 mod error;
 mod filters;
 mod gitext;


### PR DESCRIPTION
Currently, the formatting of messages is hard-coded, for example for the "show" subcommand. This is not flexible regarding configurability via command line options. In particular, it does not allow a user defined formatting.