### PR TITLE
Pre-collect names of local References in push_impl

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -481,9 +481,14 @@ fn push_impl(matches: &clap::ArgMatches) {
         .into_iter()
         .map(|issue| issue.local_refs(IssueRefType::Any))
         .abort_on_err()
-        .flat_map(git2::References::names)
-        .abort_on_err()
-        .map(String::from)
+        .flat_map(|mut refs| {
+            let names: Vec<_> = refs
+                .names()
+                .abort_on_err()
+                .map(String::from)
+                .collect();
+            names
+        })
         .collect();
 
     // set the options for the push


### PR DESCRIPTION
With git2-0.6.7, the signature of the `References::names` changed (see alexcrichton/git2-rs#245). The function now takes a mutable reference and imposes an additional lifetime constraint on the returned iterator. The latter can not out-life the `References` struct any more. This lead to compilation failures.

The problem is resolved by pre-collecting all names as `String`s within a closure.