### PR TITLE
Move the LoggableError type to the error module

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,9 @@
 // published by the Free Software Foundation.
 //
 
+use std::error::Error as EError;
+
+
 error_chain! {
     foreign_links {
         GitError(::git2::Error);
@@ -40,3 +43,25 @@ error_chain! {
         }
     }
 }
+
+
+/// Convenience trait for logging error types
+///
+/// Logs all layers of an error using the `error!` macro.
+///
+pub trait LoggableError {
+    fn log(&self);
+}
+
+impl<E> LoggableError for E
+    where E: EError
+{
+    fn log(&self) {
+        let mut current = Some(self as &EError);
+        while let Some(err) = current {
+            error!("{}", err);
+            current = err.cause();
+        }
+    }
+}
+

--- a/src/gitext/callbacks.rs
+++ b/src/gitext/callbacks.rs
@@ -12,7 +12,7 @@ use std::io::{self, Write};
 use std::result::Result as RResult;
 use std::str;
 
-use system::LoggableError;
+use error::LoggableError;
 
 
 /// Get credentials from the user

--- a/src/system/abort.rs
+++ b/src/system/abort.rs
@@ -9,7 +9,7 @@
 
 use std::process::exit;
 
-use system::LoggableError;
+use error::LoggableError;
 
 /// Aborting iterator
 ///

--- a/src/system/logger.rs
+++ b/src/system/logger.rs
@@ -9,7 +9,6 @@
 
 use log;
 use io::{stderr, Write};
-use std::error::Error;
 use std::result::Result as RResult;
 
 
@@ -42,27 +41,6 @@ impl log::Log for Logger {
     fn log(&self, record: &log::LogRecord) {
         if self.enabled(record.metadata()) {
             writeln!(stderr(), "{}", record.args()).ok();
-        }
-    }
-}
-
-
-/// Convenience trait for logging error types
-///
-/// Logs all layers of an error using the `error!` macro.
-///
-pub trait LoggableError {
-    fn log(&self);
-}
-
-impl<E> LoggableError for E
-    where E: Error
-{
-    fn log(&self) {
-        let mut current = Some(self as &Error);
-        while let Some(err) = current {
-            error!("{}", err);
-            current = err.cause();
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,7 +22,7 @@ use libgitdit::{Issue, RepositoryExt};
 use error::*;
 use error::ErrorKind as EK;
 use gitext::RemotePriorization;
-use system::{Abortable, IteratorExt, LoggableError};
+use system::{Abortable, IteratorExt};
 
 /// Open the DIT repo
 ///


### PR DESCRIPTION
It doesn't make so much sense to have it in the logger module since it doesn't depend on the specific logger implementation. Additionally, it enables a more strict dependency policy.