### PR TITLE
Enable alternative author and date via cli parameters

### DIFF
--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -79,6 +79,16 @@ subcommands:
                 help: Hash of parent
                 index: 1
                 multiple: true
+            - author:
+                help: Override the commit author
+                long: author
+                takes_value: true
+                multiple: false
+            - date:
+                help: Override the author date of the commit
+                long: date
+                takes_value: true
+                multiple: false
             - issue:
                 short: i
                 long: issue
@@ -313,6 +323,16 @@ subcommands:
                 help: Add a GPG signature
                 multiple: false
                 takes_value: false
+            - author:
+                help: Override the commit author
+                long: author
+                takes_value: true
+                multiple: false
+            - date:
+                help: Override the author date of the commit
+                long: date
+                takes_value: true
+                multiple: false
             - tempfile:
                 long: tempfile
                 help: Use a temporary file at <path> instead of .git/COMMIT_EDITMSG
@@ -384,6 +404,16 @@ subcommands:
                 help: Add a GPG signature
                 multiple: false
                 takes_value: false
+            - author:
+                help: Override the commit author
+                long: author
+                takes_value: true
+                multiple: false
+            - date:
+                help: Override the author date of the commit
+                long: date
+                takes_value: true
+                multiple: false
             - tempfile:
                 long: tempfile
                 help: Use a temporary file at <path> instead of .git/COMMIT_EDITMSG
@@ -514,6 +544,16 @@ subcommands:
                 takes_value: true
                 value_names:
                     - commithash
+            - author:
+                help: Override the commit author
+                long: author
+                takes_value: true
+                multiple: false
+            - date:
+                help: Override the author date of the commit
+                long: date
+                takes_value: true
+                multiple: false
 settings:
     AllowExternalSubcommands
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,11 @@ error_chain! {
             display("Malformed author: {}", author)
         }
 
+        MalformedDate(date: String) {
+            description("Malformed date (expected rfc3339/iso8601)")
+            display("Malformed date: {}", date)
+        }
+
         UnknownMetadataKey(key: String) {
             description("Unknown metadata key")
             display("Unknown metadata key: {}", key)

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,11 @@ error_chain! {
             display("Malformed filter spec: {}", spec)
         }
 
+        MalformedAuthor(author: String) {
+            description("Malformed author (expected author formatted like 'Foo Bar <foo@bar.net>')")
+            display("Malformed author: {}", author)
+        }
+
         UnknownMetadataKey(key: String) {
             description("Unknown metadata key")
             display("Unknown metadata key: {}", key)

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,9 +87,9 @@ fn check_refname(matches: &clap::ArgMatches) {
 ///
 fn create_message(matches: &clap::ArgMatches) {
     let repo = util::open_dit_repo();
-
     let issue = repo.cli_issue(matches);
-    let sig = repo.signature().unwrap_or_abort();
+    let author = repo.cli_author(matches);
+    let committer = repo.signature().unwrap_or_abort();
 
     // Note: The list of parents must live long enough to back the references we
     //       supply to `libgitdit::repository::RepositoryExt::create_message()`.
@@ -108,10 +108,10 @@ fn create_message(matches: &clap::ArgMatches) {
     let mut message = String::new();
     io::stdin().read_to_string(&mut message).unwrap_or_abort();
     let id = match issue {
-        Some(i) => i.add_message(&sig, &sig, message, &tree, parent_refs)
+        Some(i) => i.add_message(&author, &committer, message, &tree, parent_refs)
                     .unwrap_or_abort()
                     .id(),
-        None => repo.create_issue(&sig, &sig, message, &tree, parent_refs)
+        None => repo.create_issue(&author, &committer, message, &tree, parent_refs)
                     .unwrap_or_abort()
                     .id(),
     };
@@ -435,8 +435,8 @@ fn new_impl(matches: &clap::ArgMatches) {
     use util::message_from_args;
 
     let repo = util::open_dit_repo();
-
-    let sig = repo.signature().unwrap_or_abort();
+    let author = repo.cli_author(matches);
+    let committer = repo.signature().unwrap_or_abort();
 
     // get the message, either from the command line argument or an editor
     let message = if let Some(m) = message_from_args(matches) {
@@ -464,7 +464,7 @@ fn new_impl(matches: &clap::ArgMatches) {
     // commit the message
     let tree = repo.empty_tree().unwrap_or_abort();
     let id = repo
-        .create_issue(&sig, &sig, message.trim(), &tree, Vec::new())
+        .create_issue(&author, &committer, message.trim(), &tree, Vec::new())
         .unwrap_or_abort();
     println!("[dit][new] {}", id);
 }
@@ -511,7 +511,8 @@ fn reply_impl(matches: &clap::ArgMatches) {
     use util::message_from_args;
 
     let repo = util::open_dit_repo();
-    let sig = repo.signature().unwrap_or_abort();
+    let author = repo.cli_author(matches);
+    let committer = repo.signature().unwrap_or_abort();
 
     // NOTE: We want to do a lot of stuff early, because we want to report
     //       errors before a user spent time writing a commit message in her
@@ -574,7 +575,7 @@ fn reply_impl(matches: &clap::ArgMatches) {
     let parent_refs = Some(&parent).into_iter().chain(references.iter());
 
     // finally, create the message
-    issue.add_message(&sig, &sig, message.trim(), &tree, parent_refs)
+    issue.add_message(&author, &committer, message.trim(), &tree, parent_refs)
          .unwrap_or_abort();
 }
 
@@ -676,6 +677,8 @@ fn tag_impl(matches: &clap::ArgMatches) {
     use gitext::ReferrencesExt;
 
     let repo = util::open_dit_repo();
+    let author = repo.cli_author(matches);
+    let committer = repo.signature().unwrap_or_abort();
     let prios = repo.remote_priorization();
 
     // get the head for the issue to tag
@@ -718,7 +721,6 @@ fn tag_impl(matches: &clap::ArgMatches) {
     }
 
     // construct the message
-    let sig = repo.signature().unwrap_or_abort();
     let message = [head_commit.reply_subject().unwrap_or_default(), String::new()]
         .to_vec()
         .into_iter()
@@ -727,7 +729,7 @@ fn tag_impl(matches: &clap::ArgMatches) {
     let tree = repo.empty_tree().unwrap_or_abort();
     let parent_refs : Vec<&Commit> = Some(&head_commit).into_iter().chain(references.iter()).collect();
     let new = repo
-        .commit(None, &sig, &sig, message.trim(), &tree, &parent_refs)
+        .commit(None, &author, &committer, message.trim(), &tree, &parent_refs)
         .unwrap_or_abort();
 
     // update the head reference


### PR DESCRIPTION
git commit` allows setting the author and date of a commit via command line parameters. This PR introduces a similar interface for the "create-message", "new" and "reply" subcommands. The new interface may be used for scripting, e.g. for implementing a mail-to-message bridge.