### PR TITLE
Removal of trailing blank lines

### DIFF
--- a/lib/src/message/line_processor.rs
+++ b/lib/src/message/line_processor.rs
@@ -218,7 +218,7 @@ mod tests {
 
     #[test]
     fn quoted_lines() {
-        let mut lines = Quoted::from(vec!["foo", "bar", "", "baz"].into_iter());
+        let mut lines = Quoted::from(vec!["foo", "bar", "", "baz"]);
         assert_eq!(lines.next().expect("Premature end of input"), "> foo");
         assert_eq!(lines.next().expect("Premature end of input"), "> bar");
         assert_eq!(lines.next().expect("Premature end of input"), ">");
@@ -228,7 +228,7 @@ mod tests {
 
     #[test]
     fn left_stripped_lines() {
-        let mut lines = StripWhiteSpaceLeftIter::from(vec!["foo  ", "  bar", "  ", ""].into_iter());
+        let mut lines = StripWhiteSpaceLeftIter::from(vec!["foo  ", "  bar", "  ", ""]);
         assert_eq!(lines.next().expect("Premature end of input"), "foo  ");
         assert_eq!(lines.next().expect("Premature end of input"), "bar");
         assert_eq!(lines.next().expect("Premature end of input"), "");
@@ -238,7 +238,7 @@ mod tests {
 
     #[test]
     fn right_stripped_lines() {
-        let mut lines = StripWhiteSpaceRightIter::from(vec!["foo  ", "  bar", "  ", ""].into_iter());
+        let mut lines = StripWhiteSpaceRightIter::from(vec!["foo  ", "  bar", "  ", ""]);
         assert_eq!(lines.next().expect("Premature end of input"), "foo");
         assert_eq!(lines.next().expect("Premature end of input"), "  bar");
         assert_eq!(lines.next().expect("Premature end of input"), "");
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn lines_without_comments() {
-        let mut lines = WithoutCommentsIter::from(vec!["foo", "# bar", "#", ""].into_iter());
+        let mut lines = WithoutCommentsIter::from(vec!["foo", "# bar", "#", ""]);
         assert_eq!(lines.next().expect("Premature end of input"), "foo");
         assert_eq!(lines.next().expect("Premature end of input"), "");
         assert!(!lines.next().is_some());

--- a/lib/src/message/line_processor.rs
+++ b/lib/src/message/line_processor.rs
@@ -210,6 +210,18 @@ impl<I, S> Iterator for TrailingBlankTrimmer<I, S>
 }
 
 
+/// Convenience iterator for stripping things from a message
+///
+/// This iterator strips comments, trailing whitespace in each line and trailing
+/// blank lines.
+///
+pub type StrippingIter<I, S> = TrailingBlankTrimmer<
+    StripWhiteSpaceRightIter<
+        WithoutCommentsIter<I, S>,
+    S>,
+String>;
+
+
 
 
 #[cfg(test)]

--- a/lib/src/message/line_processor.rs
+++ b/lib/src/message/line_processor.rs
@@ -249,4 +249,15 @@ mod tests {
         assert_eq!(lines.next().expect("Premature end of input"), "");
         assert!(!lines.next().is_some());
     }
+
+    #[test]
+    fn trailing_blank_trimmer() {
+        let mut lines = TrailingBlankTrimmer::from(vec!["", "foo", "bar", "", "baz", "", ""]);
+        assert_eq!(lines.next().expect("Premature end of input"), "");
+        assert_eq!(lines.next().expect("Premature end of input"), "foo");
+        assert_eq!(lines.next().expect("Premature end of input"), "bar");
+        assert_eq!(lines.next().expect("Premature end of input"), "");
+        assert_eq!(lines.next().expect("Premature end of input"), "baz");
+        assert!(!lines.next().is_some());
+    }
 }

--- a/lib/src/message/line_processor.rs
+++ b/lib/src/message/line_processor.rs
@@ -21,12 +21,13 @@ pub struct Quoted<I, S>(I)
     where I: Iterator<Item = S>,
           S: AsRef<str>;
 
-impl<I, S> From<I> for Quoted<I, S>
-    where I: Iterator<Item = S>,
+impl<I, J, S> From<I> for Quoted<J, S>
+    where I: IntoIterator<Item = S, IntoIter = J>,
+          J: Iterator<Item = S>,
           S: AsRef<str>
 {
     fn from(lines: I) -> Self {
-        Quoted(lines)
+        Quoted(lines.into_iter())
     }
 }
 
@@ -55,12 +56,13 @@ pub struct StripWhiteSpaceLeftIter<I, S>(I)
     where I: Iterator<Item = S> + Sized,
           S: AsRef<str>;
 
-impl<I, S> From<I> for StripWhiteSpaceLeftIter<I, S>
-    where I: Iterator<Item = S>,
+impl<I, J, S> From<I> for StripWhiteSpaceLeftIter<J, S>
+    where I: IntoIterator<Item = S, IntoIter = J>,
+          J: Iterator<Item = S>,
           S: AsRef<str>
 {
     fn from(lines: I) -> Self {
-        StripWhiteSpaceLeftIter(lines)
+        StripWhiteSpaceLeftIter(lines.into_iter())
     }
 }
 
@@ -83,12 +85,13 @@ pub struct StripWhiteSpaceRightIter<I, S>(I)
     where I: Iterator<Item = S> + Sized,
           S: AsRef<str>;
 
-impl<I, S> From<I> for StripWhiteSpaceRightIter<I, S>
-    where I: Iterator<Item = S>,
+impl<I, J, S> From<I> for StripWhiteSpaceRightIter<J, S>
+    where I: IntoIterator<Item = S, IntoIter = J>,
+          J: Iterator<Item = S>,
           S: AsRef<str>
 {
     fn from(lines: I) -> Self {
-        StripWhiteSpaceRightIter(lines)
+        StripWhiteSpaceRightIter(lines.into_iter())
     }
 }
 
@@ -113,12 +116,13 @@ pub struct WithoutCommentsIter<I, S>(I)
     where I: Iterator<Item = S> + Sized,
           S: AsRef<str>;
 
-impl<I, S> From<I> for WithoutCommentsIter<I, S>
-    where I: Iterator<Item = S>,
+impl<I, J, S> From<I> for WithoutCommentsIter<J, S>
+    where I: IntoIterator<Item = S, IntoIter = J>,
+          J: Iterator<Item = S>,
           S: AsRef<str>
 {
     fn from(lines: I) -> Self {
-        WithoutCommentsIter(lines)
+        WithoutCommentsIter(lines.into_iter())
     }
 }
 

--- a/lib/src/message/mod.rs
+++ b/lib/src/message/mod.rs
@@ -27,7 +27,7 @@ use std;
 pub mod block;
 pub mod line_processor;
 
-use self::line_processor::{Quoted, StripWhiteSpaceRightIter, WithoutCommentsIter};
+use self::line_processor::{Quoted, StrippingIter};
 
 
 /// Special iterator extension for messages
@@ -56,9 +56,9 @@ pub trait LineIteratorExt<S>
     /// whitespace.
     ///
     /// Note that the iterator does not (yet) strip blank lines at the beginning
-    /// or end of a message.
+    /// of a message.
     ///
-    fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter, S>, S>;
+    fn stripped(self) -> StrippingIter<Self::Iter, S>;
 
     /// Create an iterator for quoting lines
     ///
@@ -105,8 +105,12 @@ impl<L, S> LineIteratorExt<S> for L
         Ok(())
     }
 
-    fn stripped(self) -> StripWhiteSpaceRightIter<WithoutCommentsIter<Self::Iter, S>, S> {
-        StripWhiteSpaceRightIter::from(WithoutCommentsIter::from(self))
+    fn stripped(self) -> StrippingIter<Self::Iter, S> {
+        line_processor::TrailingBlankTrimmer::from(
+            line_processor::StripWhiteSpaceRightIter::from(
+                line_processor::WithoutCommentsIter::from(self)
+            )
+        )
     }
 
     fn quoted(self) -> Quoted<Self::Iter, S> {


### PR DESCRIPTION
In the library, we provide line oriented processing of text, e.g. messages.

Various processing may yield iterators with blank lines at the beginning or at the end of messages. While the former is relatively easy to filter out using `Iterator::skip_while()`, the latter is not as easy to avoid using rust standard tools.

In the library, we currently avoid the problem by removing trailing whitespace from strings, which are collected from lines anyway. However, library users may still be interested in a tool for removing trailing blank lines.

This patch-set introduces an iterator adapter for performing this task.