### PR TITLE
Add "head" marker to head message in show subcommand

### DIFF
--- a/src/display/formatter.rs
+++ b/src/display/formatter.rs
@@ -69,6 +69,21 @@ impl<T, I> From<T> for FormattingToken<T, I>
     }
 }
 
+impl<T, I> Clone for FormattingToken<T, I>
+    where T: TokenExpander<Item = I>
+{
+    fn clone(&self) -> Self {
+        match self {
+            &FormattingToken::Expandable(ref token, _) => FormattingToken::Expandable(
+                token.clone(),
+                PhantomData
+            ),
+            &FormattingToken::Text(ref s) => FormattingToken::Text(s.clone()),
+            &FormattingToken::LineEnd => FormattingToken::LineEnd,
+        }
+    }
+}
+
 
 /// Adaption iterator for transforming lines to tokens
 ///
@@ -157,7 +172,7 @@ impl<A, I, J> LineTokens<I, J> for A
 /// Implementors of concrete formatting facilities will implement this trait for
 /// the type of items to be formatted.
 ///
-pub trait TokenExpander: Sized {
+pub trait TokenExpander: Sized + Clone {
     type Item;
     type Error;
 

--- a/src/display/formatter.rs
+++ b/src/display/formatter.rs
@@ -35,7 +35,7 @@ macro_rules! tokenvec {
 /// `Text` and `LineEnd` tokens. The latter two will be coposed to lines.
 ///
 pub enum FormattingToken<T, I>
-    where T: TokenExpander<Item = I> + Sized
+    where T: TokenExpander<Item = I>
 {
     Expandable(T, PhantomData<I>),
     Text(String),
@@ -46,7 +46,7 @@ pub enum FormattingToken<T, I>
 //       e.g. `Display` or `ToString`, but the compiler won't let us because of
 //       the implementation for `From<T>`.
 impl<T, I> From<String> for FormattingToken<T, I>
-    where T: TokenExpander<Item = I> + Sized
+    where T: TokenExpander<Item = I>
 {
     fn from(text: String) -> Self {
         FormattingToken::Text(text)
@@ -54,7 +54,7 @@ impl<T, I> From<String> for FormattingToken<T, I>
 }
 
 impl<'a, T, I> From<&'a str> for FormattingToken<T, I>
-    where T: TokenExpander<Item = I> + Sized
+    where T: TokenExpander<Item = I>
 {
     fn from(text: &str) -> Self {
         FormattingToken::Text(text.to_string())
@@ -62,7 +62,7 @@ impl<'a, T, I> From<&'a str> for FormattingToken<T, I>
 }
 
 impl<T, I> From<T> for FormattingToken<T, I>
-    where T: TokenExpander<Item = I> + Sized
+    where T: TokenExpander<Item = I>
 {
     fn from(expander: T) -> Self {
         FormattingToken::Expandable(expander, PhantomData)
@@ -88,7 +88,7 @@ pub struct LinesToTokens<I, J, T, K>
 impl<I, J, T, K> From<I> for LinesToTokens<I, J, T, K>
     where I: Iterator<Item = J>,
           J: ToString,
-          T: TokenExpander<Item = K> + Sized
+          T: TokenExpander<Item = K>
 {
     fn from(iter: I) -> Self {
         Self {
@@ -103,7 +103,7 @@ impl<I, J, T, K> From<I> for LinesToTokens<I, J, T, K>
 impl<I, J, T, K> Iterator for LinesToTokens<I, J, T, K>
     where I: Iterator<Item = J>,
           J: ToString,
-          T: TokenExpander<Item = K> + Sized
+          T: TokenExpander<Item = K>
 {
     type Item = FormattingToken<T, K>;
 
@@ -134,7 +134,7 @@ pub trait LineTokens<I, J>
 {
     /// Create a LinesToTokens from this iterator
     fn line_tokens<T, K>(self) -> LinesToTokens<I, J, T, K>
-        where T: TokenExpander<Item = K> + Sized;
+        where T: TokenExpander<Item = K>;
 }
 
 impl<A, I, J> LineTokens<I, J> for A
@@ -144,7 +144,7 @@ impl<A, I, J> LineTokens<I, J> for A
 {
     /// Create a LinesToTokens from this iterator
     fn line_tokens<T, K>(self) -> LinesToTokens<I, J, T, K>
-        where T: TokenExpander<Item = K> + Sized
+        where T: TokenExpander<Item = K>
     {
         self.into_iter().into()
     }

--- a/src/display/message.rs
+++ b/src/display/message.rs
@@ -11,7 +11,7 @@
 //!
 
 use chrono::format::strftime::StrftimeItems;
-use git2::Commit;
+use git2::{Commit, Oid};
 use libgitdit::Message;
 use libgitdit::message::block::Block;
 use libgitdit::trailer::spec::TrailerSpec;
@@ -33,6 +33,7 @@ pub enum MessageFmtToken<'a> {
     BodyText,
     Trailers,
     Trailer(TrailerSpec<'a>),
+    IfId(Oid, Vec<FormattingToken<MessageFmtToken<'a>, Commit<'a>>>),
 }
 
 impl<'a,> TokenExpander for MessageFmtToken<'a> {
@@ -94,6 +95,11 @@ impl<'a,> TokenExpander for MessageFmtToken<'a> {
                 .filter(|trailer| trailer.key.as_ref() == spec.key)
                 .line_tokens()
                 .collect(),
+            &MessageFmtToken::IfId(ref id, ref tokens) => if *id == message.id() {
+                tokens.clone()
+            } else {
+                Vec::new()
+            },
         })
     }
 }

--- a/src/display/message.rs
+++ b/src/display/message.rs
@@ -21,6 +21,7 @@ use super::formatter::{TokenExpander, FormattingToken, LineTokens};
 
 /// Tokens for formatting messages
 ///
+#[derive(Clone)]
 pub enum MessageFmtToken<'a> {
     Id(usize),
     Subject,


### PR DESCRIPTION
For users, it may be important or at least interesting to know which is the head message when viewing an issue using `git dit show`. This patch-set adds such a marker.