### PR TITLE
Fix warnings

### DIFF
--- a/src/display/message.rs
+++ b/src/display/message.rs
@@ -22,6 +22,7 @@ use super::formatter::{TokenExpander, FormattingToken, LineTokens};
 /// Tokens for formatting messages
 ///
 #[derive(Clone)]
+#[allow(unused)]
 pub enum MessageFmtToken<'a> {
     Id(usize),
     Subject,

--- a/src/display/msgtree.rs
+++ b/src/display/msgtree.rs
@@ -188,7 +188,7 @@ impl<'r, I> Iterator for TreeGraphElemLineIterator<'r, I>
             let mut parent_update = commit.parent(0).as_ref().map(Commit::id).ok();
 
             // generate graph elements for the parents currently tracked
-            let mut elems : TreeGraphElemLine = self.parents.iter_mut().map(|mut parent| {
+            let mut elems : TreeGraphElemLine = self.parents.iter_mut().map(|parent| {
                 match *parent {
                     Some(id) => if commit.id() == id {
                             // the current commit is a parent we were awaiting


### PR DESCRIPTION
Small fixes for removing compiler warnings from the compile output.

The second change might be redone by removing the enum variants, I'm not sure on that one.