### PR TITLE
Remove generic type parameters in traits by using associated type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # git-dit ChangeLog
 
+## Next
+
+Changes:
+  * Some traits in the library were refactored to not be generic over their
+    functions return types, but rather use associated types for that.
+
 ## v0.4.0 (2017-09-15)
 
 ### Binary

--- a/lib/src/trailer/spec.rs
+++ b/lib/src/trailer/spec.rs
@@ -62,19 +62,20 @@ pub const ISSUE_STATUS_SPEC: TrailerSpec = TrailerSpec {
 /// specifications in a convenient way.
 ///
 pub trait ToMap {
+    type Output: FromIterator<(String, ValueAccumulator)>;
+
     /// Construct an accumulation map
     ///
-    fn into_map<M>(self) -> M
-        where M: FromIterator<(String, ValueAccumulator)>;
+    fn into_map(self) -> Self::Output;
 }
 
 impl<'s, I, J> ToMap for I
     where I: IntoIterator<Item = J>,
           J: Borrow<TrailerSpec<'s>>
 {
-    fn into_map<M>(self) -> M
-        where M: FromIterator<(String, ValueAccumulator)>
-    {
+    type Output = ::std::collections::HashMap<String, ValueAccumulator>;
+
+    fn into_map(self) -> Self::Output {
         self.into_iter()
             .map(|spec| {
                 let s = spec.borrow();


### PR DESCRIPTION
Commit message of the first patch:

---

This patch removes one level of generic by transforming it to an
associated type.

This improves usability of the traits because of fewer generics.
Also, generic output values are problematic because every function which
wants to be generic over the trait has also to be generic over the
generic return type of the functions of the trait (see rust
documentation on associated types).

This patch improves this.

---

I bet there are more places where this can be beautified.