### PR TITLE
Refactor the GC code

### DIFF
--- a/lib/src/gc.rs
+++ b/lib/src/gc.rs
@@ -193,8 +193,17 @@ impl<'r> CollectableRefs<'r>
         Ok(retval)
     }
 
-    /// Transform directly into a reference collection iterator
+    /// Produce a reference collection iterator for multiple issues
     ///
+    /// This is a convenience function.
+    ///
+    /// # Note
+    ///
+    /// Internally, this function collects the references during the call.
+    /// Consider using the `for_issues` function in conjunction with
+    /// `flat_map()` on an issue iterator instead.
+    ///
+    #[deprecated]
     pub fn into_collector<I, J, K>(self, issues: I) -> Result<ReferenceCollector<'r>>
     where I: IntoIterator<Item = K, IntoIter = J>,
           J: Iterator<Item = K>,

--- a/lib/src/gc.rs
+++ b/lib/src/gc.rs
@@ -167,8 +167,17 @@ impl<'r> CollectableRefs<'r>
         Ok(retval)
     }
 
-    /// Perform the computation of references to collect.
+    /// Find collectable references for multiple issues
     ///
+    /// This is a convenience function.
+    ///
+    /// # Note
+    ///
+    /// Internally, this function collects the references during the call.
+    /// Consider using the `for_issues` function in conjunction with
+    /// `flat_map()` on an issue iterator instead.
+    ///
+    #[deprecated]
     pub fn into_refs<I, J, K>(self, issues: I) -> Result<Vec<Reference<'r>>>
     where I: IntoIterator<Item = K, IntoIter = J>,
           J: Iterator<Item = K>,

--- a/lib/src/iter.rs
+++ b/lib/src/iter.rs
@@ -290,6 +290,20 @@ impl<'r> Iterator for RefsReferringTo<'r> {
 }
 
 
+/// Implementation of Extend for RefsReferringTo
+///
+/// The references supplied will be returned by the extended `RefsReferringTo`
+/// iterator.
+///
+impl<'r> Extend<git2::Reference<'r>> for RefsReferringTo<'r> {
+    fn extend<I>(&mut self, references: I)
+        where I: IntoIterator<Item = git2::Reference<'r>>
+    {
+        self.current_refs.extend(references);
+    }
+}
+
+
 /// Iterator for deleting references
 ///
 /// This iterator wraps an iterator over references. All of the references

--- a/lib/src/iter.rs
+++ b/lib/src/iter.rs
@@ -220,6 +220,15 @@ impl<'r> RefsReferringTo<'r> {
         Self { refs: HashMap::new(), inner: messages, current_refs: Vec::new() }
     }
 
+    /// Push a starting point for the iteration
+    ///
+    /// The message will be pushed onto the underlying `Revwalk` used for
+    /// iterating over messages.
+    ///
+    pub fn push(&mut self, message: git2::Oid) -> Result<()> {
+        self.inner.push(message).chain_err(|| EK::CannotConstructRevwalk)
+    }
+
     /// Start watching a reference
     ///
     /// A watched reference may be returned by the iterator.

--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -29,10 +29,6 @@ use error::ErrorKind as EK;
 ///
 pub type UniqueIssues<'a> = HashSet<Issue<'a>>;
 
-/// Convenience alias for easier use of the CollectableRefs type
-///
-type CollectableRefs<'a> = gc::CollectableRefs<'a, <UniqueIssues<'a> as IntoIterator>::IntoIter>;
-
 
 /// Extension trait for Repositories
 ///
@@ -102,7 +98,7 @@ pub trait RepositoryExt {
 
     /// Produce a CollectableRefs for all issues known to the repository
     ///
-    fn collectable_refs<'a>(&'a self) -> Result<CollectableRefs<'a>>;
+    fn collectable_refs<'a>(&'a self) -> gc::CollectableRefs<'a>;
 
     /// Get an empty tree
     ///
@@ -205,9 +201,8 @@ impl RepositoryExt for git2::Repository {
             .chain_err(|| EK::CannotGetCommitForRev(id.to_string()))
     }
 
-    fn collectable_refs<'a>(&'a self) -> Result<CollectableRefs<'a>> {
-        self.issues()
-            .map(|issues| gc::CollectableRefs::new(self, issues))
+    fn collectable_refs<'a>(&'a self) -> gc::CollectableRefs<'a> {
+        gc::CollectableRefs::new(self)
     }
 
     fn issue_messages_iter<'a>(&'a self, commit: Commit<'a>) -> Result<iter::IssueMessagesIter<'a>> {

--- a/lib/src/repository.rs
+++ b/lib/src/repository.rs
@@ -96,7 +96,7 @@ pub trait RepositoryExt {
     ///
     fn issue_messages_iter<'a>(&'a self, commit: Commit<'a>) -> Result<iter::IssueMessagesIter<'a>>;
 
-    /// Produce a CollectableRefs for all issues known to the repository
+    /// Produce a CollectableRefs
     ///
     fn collectable_refs<'a>(&'a self) -> gc::CollectableRefs<'a>;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,10 +234,9 @@ fn gc_impl(matches: &clap::ArgMatches) {
 
     let refs = repo
         .collectable_refs()
-        .unwrap_or_abort()
         .consider_remote_refs(matches.is_present("consider-remote"))
         .collect_heads(collect_heads)
-        .into_refs()
+        .into_refs(repo.issues().unwrap_or_abort())
         .unwrap_or_abort();
 
     if matches.is_present("dry-run") {


### PR DESCRIPTION
This is somewhat related to #174.

This patch-set decouples the collection of references for different issues. Leaves referenced by refs of another issue will no longer be collected. Issues are no longer supplied up-front via `CollectableRefs::new()` but are fed into `CollectableRefs::into_refs()` and `CollectableRefs::into_collector()`. However, users are discouraged from using those functions now. Instead, we introduces a new function `CollectableRefs::for_issue()` which allows collecting references for a single issue without mutating or consuming the `CollectableRefs`. It enables more direct updates, e.g. when using a `FlatMap` iterator.