### PR TITLE
Enhance the gc subcommand

### DIFF
--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -210,6 +210,13 @@ subcommands:
                 help: Also collect local heads
                 multiple: false
                 takes_value: false # This may change in the future
+            - issue:
+                help: >
+                        Issue for which to collect references (collects for all
+                        issues if not specified)
+                index: 1
+                required: false
+                multiple: true
 
     - list:
         about: >

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,8 +239,8 @@ fn gc_impl(matches: &clap::ArgMatches) {
     };
 
     let refs = repo
-        .issues()
-        .unwrap_or_abort()
+        .cli_issues(matches)
+        .unwrap_or_else(|| repo.issues().unwrap_or_abort())
         .into_iter()
         .map(|issue| collect.for_issue(&issue))
         .abort_on_err()


### PR DESCRIPTION
This patch-set introduces multiple enhancements to the `git dit gc` subcommand. The main goal is to enable faster/more "responsive" collection.

It also enables collection for a subset of issues. This functionality may be used in server-side hooks, greatly enhancing the performance.

Resolves #174.