### PR TITLE
Pager via LinesExt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
 ]
 
 [dependencies]
+atty = "0.2"
 chrono = "0.4"
 error-chain = "0.11"
 git2 = "0.7"

--- a/src/main.rs
+++ b/src/main.rs
@@ -652,13 +652,9 @@ fn show_impl(matches: &clap::ArgMatches) {
         }
     };
 
-    // Spawn a pager
-    let mut pager = system::programs::pager(repo.config().unwrap_or_abort())
-        .unwrap_or_abort();
-
     // Transform the simple graph element line into an iterator over lines to
     // print via multiple steps.
-    commits
+    let result = commits
         .into_iter()
         // expand the graph element lines for each message
         .map(|commit| {
@@ -675,14 +671,10 @@ fn show_impl(matches: &clap::ArgMatches) {
         )
         // combine each line of graph elements and message
         .map(|line| format!("{} {}", line.0, line.1))
-        .write_lines(pager.stdin.as_mut().unwrap())
+        .pipe_lines(repo.pager())
         .unwrap_or_abort();
 
-    // don't trash the shell by exitting with a child still printing to it
-    let result = pager.wait().unwrap_or_abort();
-    if !result.success() {
-        std::process::exit(result.code().unwrap_or(1));
-    }
+    std::process::exit(result);
 }
 
 /// tag subcommand implementation

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@
 #[macro_use] extern crate is_match;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
+extern crate atty;
 extern crate chrono;
 extern crate git2;
 extern crate libgitdit;

--- a/src/system/write.rs
+++ b/src/system/write.rs
@@ -9,6 +9,12 @@
 
 use std::fmt::Display;
 use std::io::{self, Result as RResult, Write};
+use std::process::Child;
+
+use atty;
+
+use error::*;
+use error::ErrorKind as EK;
 
 
 /// Extension trait for convenient writing of lines
@@ -23,6 +29,37 @@ pub trait LinesExt: Sized {
     fn print_lines(self) -> RResult<()> {
         let mut stream = io::stdout();
         self.write_lines(&mut stream)
+    }
+
+    /// Pipe lines to a child process
+    ///
+    /// If stdout is a TTY, pipe the lines to the child process and wait until
+    /// it is closed. Otherwise, just print them to stdout.
+    ///
+    /// Returns `0` on success and a non-null return code if an error occured
+    /// in the child.
+    ///
+    /// # Note
+    ///
+    /// The `child` provided must provide an `stdin` field which is not `None`,
+    /// e.g. it must accept data via standart input. Otherwise, this function
+    /// panics.
+    ///
+    fn pipe_lines(self, mut child: Child) -> Result<i32> {
+        if atty::is(atty::Stream::Stdout) {
+            // NOTE: this unwrap is ok via the requirements on `child`.
+            self.write_lines(child.stdin.as_mut().unwrap())
+                .chain_err(|| Error::from(EK::WrappedIOError))?;
+
+            child
+                .wait()
+                .chain_err(|| Error::from(EK::ChildError))
+                .map(|result| result.code().unwrap_or(1))
+        } else {
+            self.print_lines()
+                .chain_err(|| Error::from(EK::WrappedIOError))
+                .map(|_| 0)
+        }
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,6 +13,7 @@ use regex::{Regex, Match};
 use std::fs::File;
 use std::io;
 use std::path::PathBuf;
+use std::process::Child;
 use std::str::FromStr;
 
 use libgitdit::message::LineIteratorExt;
@@ -23,7 +24,7 @@ use libgitdit::{Issue, RepositoryExt};
 use error::*;
 use error::ErrorKind as EK;
 use gitext::RemotePriorization;
-use system::{Abortable, IteratorExt};
+use system::{Abortable, IteratorExt, programs};
 
 /// Open the DIT repo
 ///
@@ -96,6 +97,12 @@ pub trait RepositoryUtil<'r> {
 
     /// Get remote priorization from the config
     fn remote_priorization(&self) -> RemotePriorization;
+
+    /// Get a pager
+    ///
+    /// Get a pager suitable for paging output
+    ///
+    fn pager(&self) -> Child;
 }
 
 impl<'r> RepositoryUtil<'r> for Repository {
@@ -266,6 +273,10 @@ impl<'r> RepositoryUtil<'r> for Repository {
             .get_str("dit.remote-prios")
             .unwrap_or("*")
             .into()
+    }
+
+    fn pager(&self) -> Child {
+        programs::pager(self.config().unwrap_or_abort()).unwrap_or_abort()
     }
 }
 


### PR DESCRIPTION
Instead of adding boilerplate code each time we use the pager, add a function to the `LinesExt` which handles paged output. The new function handles both waiting for the pager to be closed and TTY detection.

Superseeds #165.