### PR TITLE
Make documentation of get-issue-metadata less ambiguous

### DIFF
--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -111,8 +111,8 @@ subcommands:
 
     - get-issue-metadata:
         about: >
-                 Prints a log of commit tags, from the supplied issue head to
-                 the initial issue message.
+                 Prints metadata tags, beginning from the supplied message id
+                 (e.g. an issue head) to the initial issue message.
         version: 0.4.0
         authors:
             - Matthias Beyer <mail@beyermatthias.de>


### PR DESCRIPTION
Apparently, it was not clear enough that the subcommand accepts a
message id rather than an issue id.